### PR TITLE
Fix double hashing of passwords

### DIFF
--- a/server/src/model/documents/UserDocument.ts
+++ b/server/src/model/documents/UserDocument.ts
@@ -21,7 +21,9 @@ export class UserCredentials {
   // }
 })
 @pre<UserDocument>('save', async function(next) {
-  if (!this.isModified('password')) {
+  const isHashed = /^\$2[ayb]\$.{56}$/.test(this.password);
+
+  if (isHashed) {
     return next();
   }
 


### PR DESCRIPTION
# :ticket: Description
Fixes a bug which would double hash a password of a User if the user got edited without changing it's password. This was due to the fact that the encryption/decryption library set all fields which were decrypted to 'modified'. However that state was used to determine if a password needs to get hashed before saving the User to the DB.

Now, the solution is: The pre-save hook of mongoose checks if the password looks like a bcrypt hash. If it does NOT it gets hashed. If it does the hashing step is skipped.
<!-- Describe this PR -->
