### PR TITLE
Add testing mode flag & more logging to MailService.

### DIFF
--- a/server/config/default.yml
+++ b/server/config/default.yml
@@ -10,6 +10,7 @@ database:
     authMechanism: 'SCRAM-SHA-1'
 
 mailing:
+  testingMode: false
   templates: 
   # Replacements:
   # {{name}}: Name of user


### PR DESCRIPTION
# :ticket: Description
Primarily this adds more logging to the MailService. Furthermore this introduces a `testingMode` which can be used to connect to ethereal by providing the user and pass accordingly. This replaces the auto-use of ethereal in non-production environments.
<!-- Describe this PR -->