### PR TITLE
Remove building shared package from workflow.

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,12 +23,6 @@ jobs:
           yarn install
         env:
           CI: true
-      - name: Build shared package
-        working-directory: shared/
-        run: |
-          yarn build
-        env:
-          CI: true
       - name: Check code quality on client
         working-directory: client/
         run: |
@@ -50,12 +44,6 @@ jobs:
       - name: Install node packages
         run: |
           yarn install
-        env:
-          CI: true
-      - name: Build shared package
-        working-directory: shared/
-        run: |
-          yarn build
         env:
           CI: true
       - name: Check code quality on server

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "shared"
   ],
   "scripts": {
+    "postinstall": "yarn build:shared",
     "format": "yarn format:client && yarn format:server && yarn format:shared",
     "format:client": "echo Formatting client && cd ./client && yarn format",
     "format:server": "echo Formatting server && cd ./server && yarn format",


### PR DESCRIPTION
# :ticket: Description
This is due to the fact that this is now included as postinstall script in the root package.json.