### PR TITLE
Substitute tutor cannot view attendance page

### DIFF
--- a/client/src/components/forms/TutorialForm.tsx
+++ b/client/src/components/forms/TutorialForm.tsx
@@ -94,7 +94,6 @@ export type TutorialFormSubmitCallback = FormikSubmitCallback<TutorialFormState>
 
 interface Props extends Omit<FormikBaseFormProps<TutorialFormState>, CommonlyUsedFormProps> {
   tutors: User[];
-  allTutorials: TutorialWithFetchedCorrectors[];
   tutorial?: TutorialWithFetchedCorrectors;
   onSubmit: TutorialFormSubmitCallback;
 }
@@ -112,18 +111,7 @@ function getAllWeeklyDatesBetween(startDate: Date, endDate: Date): Date[] {
   return dates;
 }
 
-function findFirstEmptySlot(tutorials: { slot: number }[]): number {
-  for (let i = 0; i <= tutorials.length; i++) {
-    if (tutorials.findIndex(tut => tut.slot === i) === -1) {
-      return i;
-    }
-  }
-
-  return tutorials.length + 1;
-}
-
 export function getInitialTutorialFormValues(
-  allTutorials: TutorialWithFetchedCorrectors[],
   tutorial?: TutorialWithFetchedCorrectors
 ): TutorialFormState {
   const startDate = new Date(Date.now()).toISOString();
@@ -158,17 +146,10 @@ export function getInitialTutorialFormValues(
   };
 }
 
-function TutorialForm({
-  tutors,
-  tutorial,
-  allTutorials,
-  onSubmit,
-  className,
-  ...other
-}: Props): JSX.Element {
+function TutorialForm({ tutors, tutorial, onSubmit, className, ...other }: Props): JSX.Element {
   const classes = useStyles();
 
-  const initialFormValues: TutorialFormState = getInitialTutorialFormValues(allTutorials, tutorial);
+  const initialFormValues: TutorialFormState = getInitialTutorialFormValues(tutorial);
 
   const userConverterFunctions = {
     itemToString: (tutor: User) => `${tutor.lastname}, ${tutor.firstname}`,

--- a/client/src/hooks/fetching/Tutorial.ts
+++ b/client/src/hooks/fetching/Tutorial.ts
@@ -1,6 +1,6 @@
 import { Student } from 'shared/dist/model/Student';
 import { SubstituteDTO, Tutorial, TutorialDTO } from 'shared/dist/model/Tutorial';
-import { User } from 'shared/dist/model/User';
+import { User, TutorInfo } from 'shared/dist/model/User';
 import {
   StudentByTutorialSlotSummaryMap,
   StudentScheinCriteriaSummaryMap,
@@ -41,7 +41,7 @@ export async function getAllTutorialsAndFetchTutor(): Promise<TutorialWithFetche
 }
 
 export async function getAllTutorialsAndFetchStudents(): Promise<TutorialWithFetchedStudents[]> {
-  const tutorials = await getAllTutorialsAndFetchTutor();
+  const tutorials = await getAllTutorials();
   const promises: Promise<TutorialWithFetchedStudents>[] = [];
 
   for (const tutorial of tutorials) {
@@ -87,7 +87,7 @@ export async function getTutorialAndFetchTutor(id: string): Promise<TutorialWith
 export async function getTutorialAndFetchTutorAndStudents(
   id: string
 ): Promise<TutorialWithFetchedStudents> {
-  const tutorial = await getTutorialAndFetchTutor(id);
+  const tutorial = await getTutorial(id);
   const students = await getStudentsOfTutorial(tutorial.id);
 
   return { ...tutorial, students };
@@ -170,15 +170,15 @@ export async function deleteTutorial(id: string): Promise<void> {
   }
 }
 
-// export async function getTutorOfTutorial(id: string): Promise<User | undefined> {
-//   const response = await axios.get<User | undefined>(`tutorial/${id}/user`);
+export async function getTutorInfoOfTutorial(id: string): Promise<TutorInfo | undefined> {
+  const response = await axios.get<TutorInfo | undefined>(`tutorial/${id}/tutor`);
 
-//   if (response.status === 200) {
-//     return response.data;
-//   }
+  if (response.status === 200) {
+    return response.data;
+  }
 
-//   return Promise.reject(`Wrong response code (${response.status}).`);
-// }
+  return Promise.reject(`Wrong response code (${response.status}).`);
+}
 
 export async function getStudentsOfTutorial(id: string): Promise<Student[]> {
   const response = await axios.get<Student[]>(`tutorial/${id}/student`);

--- a/client/src/typings/types.ts
+++ b/client/src/typings/types.ts
@@ -15,8 +15,8 @@ export interface TutorialWithFetchedTutor extends Omit<Tutorial, 'tutor'> {
   tutor?: User;
 }
 
-export interface TutorialWithFetchedStudents extends Omit<Tutorial, 'tutor' | 'students'> {
-  tutor?: User;
+export interface TutorialWithFetchedStudents extends Omit<Tutorial, 'students'> {
+  // tutor?: User;
   students: Student[];
 }
 

--- a/client/src/util/helperFunctions.ts
+++ b/client/src/util/helperFunctions.ts
@@ -1,15 +1,22 @@
 import { format } from 'date-fns';
 import deLocale from 'date-fns/locale/de';
-import { NamedElement } from 'shared/dist/model/Common';
+import { PointMap } from 'shared/dist/model/Points';
 import { ScheinExam } from 'shared/dist/model/Scheinexam';
 import { Student } from 'shared/dist/model/Student';
-import { PointMap } from 'shared/dist/model/Points';
+
+interface EntityWithName {
+  lastname: string;
+  firstname: string;
+}
 
 interface NameOptions {
   lastNameFirst: boolean;
 }
 
-export function getNameOfEntity(entity: NamedElement, options: Partial<NameOptions> = {}): string {
+export function getNameOfEntity(
+  entity: EntityWithName,
+  options: Partial<NameOptions> = {}
+): string {
   if (options.lastNameFirst) {
     return `${entity.lastname}, ${entity.firstname} `;
   } else {

--- a/client/src/view/attendance/AttendanceManager.tsx
+++ b/client/src/view/attendance/AttendanceManager.tsx
@@ -217,22 +217,20 @@ function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element 
 
     const studentsPrintObjects = students
       .sort((a, b) => {
-        const nameOfA = `${a.lastname}, ${a.firstname}`;
-        const nameOfB = `${b.lastname}, ${b.firstname}`;
+        const nameOfA = getNameOfEntity(a, { lastNameFirst: true });
+        const nameOfB = getNameOfEntity(b, { lastNameFirst: true });
 
         return nameOfA.localeCompare(nameOfB);
       })
       .map(({ firstname, lastname }) => ({
-        firstname,
-        lastname,
+        name: getNameOfEntity({ lastname, firstname }, { lastNameFirst: true }),
         signing: '',
       }));
 
     printJS({
       printable: studentsPrintObjects,
       properties: [
-        { field: 'lastname', displayName: 'Nachname' },
-        { field: 'firstname', displayName: 'Vorname' },
+        { field: 'name', displayName: 'Name' },
         { field: 'signing', displayName: 'Unterschrift' },
       ],
       type: 'json',

--- a/client/src/view/attendance/AttendanceManager.tsx
+++ b/client/src/view/attendance/AttendanceManager.tsx
@@ -4,8 +4,11 @@ import { compareAsc, format } from 'date-fns';
 import deLocale from 'date-fns/locale/de';
 import printJS from 'print-js';
 import React, { ChangeEvent, useEffect, useState } from 'react';
+import { Attendance, AttendanceDTO, AttendanceState } from 'shared/dist/model/Attendance';
+import { LoggedInUser, TutorInfo } from 'shared/dist/model/User';
 import CustomSelect from '../../components/CustomSelect';
 import DateOfTutorialSelection from '../../components/DateOfTutorialSelection';
+import LoadingSpinner from '../../components/LoadingSpinner';
 import TableWithPadding from '../../components/TableWithPadding';
 import { useAxios } from '../../hooks/FetchingService';
 import { useLogin } from '../../hooks/LoginService';
@@ -14,14 +17,11 @@ import {
   TutorialWithFetchedStudents as Tutorial,
 } from '../../typings/types';
 import {
+  getDisplayStringForTutorial,
   getNameOfEntity,
   parseDateToMapKey,
-  getDisplayStringForTutorial,
 } from '../../util/helperFunctions';
 import StudentAttendanceRow, { NoteFormCallback } from './components/StudentsAttendanceRow';
-import LoadingSpinner from '../../components/LoadingSpinner';
-import { LoggedInUser } from 'shared/dist/model/User';
-import { Attendance, AttendanceState, AttendanceDTO } from 'shared/dist/model/Attendance';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -62,8 +62,6 @@ function getAvailableDates(
     const substituteTutorial = user.substituteTutorials.find(sub => sub.id === tutorial.id);
 
     if (substituteTutorial) {
-      console.log(substituteTutorial.dates);
-
       return tutorial.dates.filter(
         date => substituteTutorial.dates.findIndex(d => compareAsc(date, d) === 0) !== -1
       );
@@ -84,6 +82,8 @@ function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element 
   const [isLoading, setIsLoading] = useState(false);
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [students, setStudents] = useState<StudentWithFetchedTeam[]>([]);
+
+  const [tutorInfo, setTutorInfo] = useState<TutorInfo | undefined>();
   const [tutorial, setTutorial] = useState<Tutorial | undefined>();
   const [tutorials, setTutorials] = useState<Tutorial[]>([]);
 
@@ -93,6 +93,7 @@ function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element 
     setAttendanceOfStudent,
     getAllTutorialsAndFetchStudents,
     fetchTeamsOfStudents,
+    getTutorInfoOfTutorial,
   } = useAxios();
 
   useEffect(() => {
@@ -102,12 +103,13 @@ function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element 
   useEffect(() => {
     if (tutorial) {
       fetchTeamsOfStudents(tutorial.students).then(response => setStudents(response));
+      getTutorInfoOfTutorial(tutorial.id).then(info => setTutorInfo(info));
     } else {
       setStudents([]);
     }
 
     setDate(undefined);
-  }, [tutorial, fetchTeamsOfStudents]);
+  }, [tutorial, fetchTeamsOfStudents, getTutorInfoOfTutorial]);
 
   useEffect(() => {
     if (!tutorialFromProps) {
@@ -203,8 +205,8 @@ function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element 
     }
 
     const tutorialDisplay = getDisplayStringForTutorial(tutorial);
-    const tutorName = tutorial.tutor
-      ? `${tutorial.tutor.firstname} ${tutorial.tutor.lastname}`
+    const tutorName = tutorInfo
+      ? getNameOfEntity(tutorInfo, { lastNameFirst: true })
       : 'KEIN TUTOR';
 
     const substitutePart = isSubstituteTutor(tutorial, userData)
@@ -274,7 +276,7 @@ function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element 
               color='primary'
               className={classes.printButton}
               onClick={printAttendanceSheet}
-              disabled={!tutorial || !date}
+              disabled={!tutorial || !date || !tutorInfo}
             >
               Unterschriftenliste ausdrucken
             </Button>

--- a/client/src/view/tutorialmanagement/TutorialManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialManagement.tsx
@@ -107,7 +107,7 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
       setTutorials(allTutorials);
 
       enqueueSnackbar('Tutorium wurde erstellt.', { variant: 'success' });
-      resetForm({ values: getInitialTutorialFormValues(allTutorials) });
+      resetForm({ values: getInitialTutorialFormValues() });
     } catch (reason) {
       console.log(reason);
     } finally {
@@ -148,7 +148,6 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
       content: (
         <TutorialForm
           tutorial={tutorial}
-          allTutorials={tutorials}
           tutors={tutors}
           onSubmit={editTutorial(tutorial)}
           onCancelClicked={() => dialog.hide()}
@@ -200,13 +199,7 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
       ) : (
         <TableWithForm
           title='Neues Tutorium erstellen'
-          form={
-            <TutorialForm
-              tutors={tutors}
-              onSubmit={handleCreateTutorial}
-              allTutorials={tutorials}
-            />
-          }
+          form={<TutorialForm tutors={tutors} onSubmit={handleCreateTutorial} />}
           items={tutorials}
           createRowFromItem={tutorial => (
             <TutorialTableRow

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   mongo:
     image: mongo
     container_name: mongo
+    restart: always
     ports:
       - 27017:27017
     networks:
@@ -28,6 +29,7 @@ services:
   tms-server:
     image: tutor-management-system
     container_name: tms-server
+    restart: on-failure:1
     depends_on:
       - mongo
     ports:

--- a/server/src/services/tutorial-service/TutorialService.class.ts
+++ b/server/src/services/tutorial-service/TutorialService.class.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { Types } from 'mongoose';
 import { Student } from 'shared/dist/model/Student';
 import { SubstituteDTO, Tutorial, TutorialDTO } from 'shared/dist/model/Tutorial';
-import { User } from 'shared/dist/model/User';
+import { User, TutorInfo } from 'shared/dist/model/User';
 import { Ref } from 'typegoose';
 import { isDocument } from 'typegoose/lib/utils';
 import { getIdOfDocumentRef } from '../../helpers/documentHelpers';
@@ -155,6 +155,20 @@ class TutorialService {
     }
 
     return tutorial;
+  }
+
+  public async getTutorInfoOfTutorial(id: string): Promise<TutorInfo> {
+    const tutorial = await this.getDocumentWithID(id);
+
+    if (!tutorial.tutor) {
+      throw new BadRequestError('Tutorial does not have a tutor.');
+    }
+
+    const { lastname, firstname } = await userService.getDocumentWithId(
+      getIdOfDocumentRef(tutorial.tutor)
+    );
+
+    return { lastname, firstname };
   }
 
   public async getCorrectorsOfTutorial(id: string): Promise<User[]> {

--- a/server/src/services/tutorial-service/TutorialService.routes.ts
+++ b/server/src/services/tutorial-service/TutorialService.routes.ts
@@ -2,7 +2,7 @@ import Router from 'express-promise-router';
 import { Role } from 'shared/dist/model/Role';
 import { Student } from 'shared/dist/model/Student';
 import { SubstituteDTO, Tutorial } from 'shared/dist/model/Tutorial';
-import { User } from 'shared/dist/model/User';
+import { User, TutorInfo } from 'shared/dist/model/User';
 import {
   validateAgainstTutorialDTO,
   validateAgainstSubstituteDTO,
@@ -76,6 +76,21 @@ tutorialRouter.delete('/:id', ...checkRoleAccess(Role.ADMIN), async (req, res) =
 
   res.status(204).send();
 });
+
+tutorialRouter.get(
+  '/:id/tutor',
+  ...checkAccess(
+    hasUserOneOfRoles([Role.ADMIN, Role.EMPLOYEE]),
+    isUserTutorOfTutorial,
+    isUserSubstituteOfTutorial
+  ),
+  async (req, res) => {
+    const id: string = req.params.id;
+    const tutorInfo: TutorInfo = await tutorialService.getTutorInfoOfTutorial(id);
+
+    res.json(tutorInfo);
+  }
+);
 
 tutorialRouter.get(
   '/:id/corrector',

--- a/shared/src/model/User.ts
+++ b/shared/src/model/User.ts
@@ -36,3 +36,8 @@ export interface CreateUserDTO extends UserDTO {
 export interface NewPasswordDTO {
   password: string;
 }
+
+export interface TutorInfo {
+  lastname: string;
+  firstname: string;
+}


### PR DESCRIPTION
# :ticket: Description
Fixes the bug where a substitute tutor cannot load the attendance page. This introduces a new endpoint `/tutorial/:id/tutor` which only returns the name of the tutor of the tutorial. 
<!-- Describe this PR -->

# :lock: Closes
- Closes #53 
<!-- Which issue(s) is (are) being closed by the PR? -->
