### PR TITLE
Tutors cannot retrieve schein statuses of their students

### DIFF
--- a/client/src/hooks/fetching/Tutorial.ts
+++ b/client/src/hooks/fetching/Tutorial.ts
@@ -202,7 +202,7 @@ export async function getScheinCriteriaSummariesOfAllStudentsOfTutorial(
   id: string
 ): Promise<StudentScheinCriteriaSummaryMap> {
   const response = await axios.get<StudentScheinCriteriaSummaryMap>(
-    `tutorial/${id}/student/scheincriteria`
+    `scheincriteria/tutorial/${id}`
   );
 
   if (response.status === 200) {

--- a/client/src/view/management/components/ExtendableStudentRow.tsx
+++ b/client/src/view/management/components/ExtendableStudentRow.tsx
@@ -219,7 +219,7 @@ function ExtendableStudentRow({
 
       {showInfoBox && summary && (
         <TableRow>
-          <TableCell className={classes.infoRowCell} align='center' colSpan={4}>
+          <TableCell className={classes.infoRowCell} align='center' colSpan={5}>
             <div className={classes.infoRowContent}>
               <ScheinCriteriaStatusTable summary={Object.values(summary.scheinCriteriaSummary)} />
             </div>

--- a/client/src/view/studentmanagement/Studentmanagement.tsx
+++ b/client/src/view/studentmanagement/Studentmanagement.tsx
@@ -66,7 +66,9 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
         getTeamsOfTutorial(params.tutorialId),
       ]);
 
-      getScheinCriteriaSummariesOfAllStudentsOfTutorial(params.tutorialId).then(response => setSummaries(response));
+      getScheinCriteriaSummariesOfAllStudentsOfTutorial(params.tutorialId).then(response =>
+        setSummaries(response)
+      );
       setStudents(
         studentsResponse.sort((a, b) =>
           getNameOfEntity(a, { lastNameFirst: true }).localeCompare(

--- a/client/src/view/studentmanagement/Studentmanagement.tsx
+++ b/client/src/view/studentmanagement/Studentmanagement.tsx
@@ -53,7 +53,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
     createStudentAndFetchTeam,
     editStudentAndFetchTeam: editStudentRequest,
     deleteStudent: deleteStudentRequest,
-    getScheinCriteriaSummaryOfAllStudents,
+    getScheinCriteriaSummariesOfAllStudentsOfTutorial,
   } = useAxios();
   const dialog = useDialog();
 
@@ -66,7 +66,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
         getTeamsOfTutorial(params.tutorialId),
       ]);
 
-      getScheinCriteriaSummaryOfAllStudents().then(response => setSummaries(response));
+      getScheinCriteriaSummariesOfAllStudentsOfTutorial(params.tutorialId).then(response => setSummaries(response));
       setStudents(
         studentsResponse.sort((a, b) =>
           getNameOfEntity(a, { lastNameFirst: true }).localeCompare(
@@ -80,7 +80,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
   }, [
     getStudentsOfTutorialAndFetchTeams,
     getTeamsOfTutorial,
-    getScheinCriteriaSummaryOfAllStudents,
+    getScheinCriteriaSummariesOfAllStudentsOfTutorial,
     params.tutorialId,
   ]);
 

--- a/server/src/services/scheincriteria-service/ScheincriteriaService.class.ts
+++ b/server/src/services/scheincriteria-service/ScheincriteriaService.class.ts
@@ -19,6 +19,7 @@ import {
 import { Student } from 'shared/dist/model/Student';
 import { validateSchema } from 'shared/dist/validators/helper';
 import * as Yup from 'yup';
+import Logger from '../../helpers/Logger';
 import { TypegooseDocument } from '../../helpers/typings';
 import ScheincriteriaModel, {
   ScheincriteriaDocument,
@@ -33,7 +34,6 @@ import {
 } from '../../model/scheincriteria/ScheincriteriaMetadata';
 import studentService from '../student-service/StudentService.class';
 import tutorialService from '../tutorial-service/TutorialService.class';
-import Logger from '../../helpers/Logger';
 
 interface ScheincriteriaWithId {
   criteriaId: string;

--- a/server/src/services/tutorial-service/TutorialService.routes.ts
+++ b/server/src/services/tutorial-service/TutorialService.routes.ts
@@ -2,24 +2,22 @@ import Router from 'express-promise-router';
 import { Role } from 'shared/dist/model/Role';
 import { Student } from 'shared/dist/model/Student';
 import { SubstituteDTO, Tutorial } from 'shared/dist/model/Tutorial';
-import { User, TutorInfo } from 'shared/dist/model/User';
+import { TutorInfo, User } from 'shared/dist/model/User';
 import {
-  validateAgainstTutorialDTO,
   validateAgainstSubstituteDTO,
+  validateAgainstTutorialDTO,
 } from 'shared/dist/validators/Tutorial';
 import {
-  checkRoleAccess,
   checkAccess,
+  checkRoleAccess,
   hasUserOneOfRoles,
-  isUserTutorOfTutorial,
-  isUserSubstituteOfTutorial,
   isUserCorrectorOfTutorial,
+  isUserSubstituteOfTutorial,
+  isUserTutorOfTutorial,
 } from '../../middleware/AccessControl';
 import { validateRequestBody } from '../../middleware/Validation';
 import teamRouter from '../team-service/TeamService.routes';
 import tutorialService from './TutorialService.class';
-import { ScheincriteriaSummaryByStudents } from 'shared/dist/model/ScheinCriteria';
-import scheincriteriaService from '../scheincriteria-service/ScheincriteriaService.class';
 
 const tutorialRouter = Router();
 

--- a/server/src/services/tutorial-service/TutorialService.routes.ts
+++ b/server/src/services/tutorial-service/TutorialService.routes.ts
@@ -120,24 +120,6 @@ tutorialRouter.get(
 );
 
 tutorialRouter.get(
-  '/:id/student/scheincriteria',
-  ...checkAccess(
-    hasUserOneOfRoles([Role.ADMIN, Role.EMPLOYEE]),
-    isUserTutorOfTutorial,
-    isUserSubstituteOfTutorial,
-    isUserCorrectorOfTutorial
-  ),
-  async (req, res) => {
-    const id: string = req.params.id;
-    const result: ScheincriteriaSummaryByStudents = await scheincriteriaService.getCriteriaResultsOfStudentsOfTutorial(
-      id
-    );
-
-    res.json(result);
-  }
-);
-
-tutorialRouter.get(
   '/:id/substitute',
   ...checkRoleAccess([Role.ADMIN, Role.EMPLOYEE]),
   async (req, res) => {


### PR DESCRIPTION
# :ticket: Description
Fixes the issue of tutors not able to retrieve the schein statuses of their students. This is done by using an endpoint specially made for this purpose.
<!-- Describe this PR -->

# :lock: Closes
- Closes #60 
<!-- Which issue(s) is (are) being closed by the PR? -->
