### PR TITLE
Allow 6 digit matriculation numbers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,7 @@
 # Tutor Management System
 
 ![](https://github.com/Dudrie/Tutor-Management-System/workflows/Code%20Quality/badge.svg)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=Dudrie/Tutor-Management-System)](https://dependabot.com)
 
 The Tutor Management System (short _TMS_) aims to be a tool used at universitites (in Germany). It can be used to track the requirements which a student has to fulfill to be allowed to write the exam. It can (among other things) track the points gained by the students in their homeworks, how often a student attended the tutorial and how often a student presented a solution.
 

--- a/client/src/components/forms/StudentForm.tsx
+++ b/client/src/components/forms/StudentForm.tsx
@@ -15,9 +15,9 @@ const validationSchema = Yup.object().shape({
     .required('Benötigt')
     .test({
       test: function(this, matriculationNo: number) {
-        return !!matriculationNo && matriculationNo.toString().length === 7;
+        return !!matriculationNo && matriculationNo.toString().length >= 6;
       },
-      message: 'Muss siebenstellig sein',
+      message: 'Muss mind. 6 Stellen haben',
     }),
 });
 

--- a/shared/src/validators/Student.ts
+++ b/shared/src/validators/Student.ts
@@ -8,9 +8,7 @@ const StudentDTOSchema = Yup.object().shape<StudentDTO>({
   email: Yup.string(),
   firstname: Yup.string().required(),
   lastname: Yup.string().required(),
-  matriculationNo: Yup.string()
-    .required()
-    .length(7),
+  matriculationNo: Yup.string().required(),
   team: YupIdShape.nullable(),
   tutorial: YupIdShape.required(),
 });


### PR DESCRIPTION
# :ticket: Description
Different universities have different matriculation number length. This PR makes it possible to enter 6 (or more) digit matriculation numbers instead of the fixed length of 7. 

However this itself could only be a "hotfix" and more adjustments could be neccessary. One overall solution would be to provide a setting for the minimal length after the setting system has been added.
<!-- Describe this PR -->

# :lock: Closes
- Closes #52 
<!-- Which issue(s) is (are) being closed by the PR? -->
