### PR TITLE
Fix page being cut off at the bottom in Firefox.

### DIFF
--- a/client/src/components/TableWithForm.tsx
+++ b/client/src/components/TableWithForm.tsx
@@ -2,6 +2,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React, { useState } from 'react';
 import OpenableFormWithFab from './OpenableFormWithFab';
 import TableWithPadding, { TableWithPaddingProps } from './TableWithPadding';
+import clsx from 'clsx';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -11,6 +12,9 @@ const useStyles = makeStyles((theme: Theme) =>
       height: 48,
       marginTop: theme.spacing(1),
       marginBottom: theme.spacing(-8),
+    },
+    list: {
+      marginBottom: theme.spacing(1),
     },
     listWithClosedEditor: {
       marginTop: theme.spacing(8),
@@ -65,7 +69,12 @@ function TableWithForm<T>({
 
       {topBarContent && !isEditorOpen && <div className={classes.topBar}>{topBarContent}</div>}
 
-      <div className={isEditorOpen ? classes.listWithOpenEditor : classes.listWithClosedEditor}>
+      <div
+        className={clsx(classes.list, {
+          [classes.listWithOpenEditor]: isEditorOpen,
+          [classes.listWithClosedEditor]: !isEditorOpen,
+        })}
+      >
         <TableWithPadding
           items={items}
           createRowFromItem={createRowFromItem}

--- a/client/src/view/App.tsx
+++ b/client/src/view/App.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme: Theme) =>
     content: {
       width: 0,
       flexGrow: 1,
-      height: 'inherit',
+      height: '100%',
       '& > *': {
         height: 'inherit',
         padding: theme.spacing(2, 2, 1, 2),

--- a/client/src/view/App.tsx
+++ b/client/src/view/App.tsx
@@ -24,16 +24,15 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     contentWrapper: {
       display: 'flex',
-      flexGrow: 1,
-      height: '100%',
+      flex: '1 1 auto',
+      overflowY: 'auto',
     },
     content: {
       width: 0,
       flexGrow: 1,
-      height: '100%',
+      height: 'inherit',
       '& > *': {
         height: 'inherit',
-        overflowY: 'auto',
         padding: theme.spacing(2, 2, 1, 2),
         position: 'relative',
       },


### PR DESCRIPTION
# :ticket: Description
Fixes an issue with the height of the main page in Firefox. The previous CSS style lead to cut off pages at the bottom in said browser.
<!-- Describe this PR -->

# :lock: Closes
- Closes #77 
<!-- Which issue(s) is (are) being closed by the PR? -->
