### PR TITLE
Make substitute tutors removable after setting them

### DIFF
--- a/client/src/components/CustomSelect.tsx
+++ b/client/src/components/CustomSelect.tsx
@@ -38,7 +38,7 @@ export interface CustomSelectProps<T>
   name?: string;
   label: string;
   emptyPlaceholder: string;
-  hasNoneItem?: boolean;
+  nameOfNoneItem?: string;
   helperText?: React.ReactNode;
   items: T[];
   itemToString: ItemToString<T>;
@@ -91,7 +91,7 @@ function CustomSelect<T>({
   items: itemsFromProps,
   itemToString,
   itemToValue,
-  hasNoneItem,
+  nameOfNoneItem,
   isItemSelected,
   multiple,
   FormControlProps,
@@ -104,9 +104,9 @@ function CustomSelect<T>({
     );
   }
 
-  if (multiple && hasNoneItem) {
+  if (multiple && !!nameOfNoneItem) {
     throw new Error(
-      `[CustomSelect] -- You have set the Select '${name}' to allow multiple selections and you also set 'hasNoneItem' to true. This combination of properties is not supported because 'multiple = true' Selects already support deselecting a selection.`
+      `[CustomSelect] -- You have set the Select '${name}' to allow multiple selections and you also provided 'nameOfNoneItem'. This combination of properties is not supported because 'multiple = true' Selects do not need an extra 'none item'.`
     );
   }
 
@@ -116,7 +116,9 @@ function CustomSelect<T>({
   const inputLabel = useRef<HTMLLabelElement>(null);
   const [labelWidth, setLabelWidth] = useState(0);
 
-  const items: (T | EmptyItem)[] = hasNoneItem ? [NONE_ITEM, ...itemsFromProps] : itemsFromProps;
+  const items: (T | EmptyItem)[] = !!nameOfNoneItem
+    ? [NONE_ITEM, ...itemsFromProps]
+    : itemsFromProps;
 
   useEffect(() => {
     const label = inputLabel.current;
@@ -152,7 +154,7 @@ function CustomSelect<T>({
           if (item instanceof EmptyItem) {
             return (
               <MenuItem key={NONE_ITEM.id} value={''}>
-                {NONE_ITEM.name}
+                <i>{nameOfNoneItem}</i>
               </MenuItem>
             );
           }

--- a/client/src/components/forms/TutorialForm.tsx
+++ b/client/src/components/forms/TutorialForm.tsx
@@ -229,7 +229,7 @@ function TutorialForm({ tutors, tutorial, onSubmit, className, ...other }: Props
             name='correctors'
             label='Korrektoren'
             emptyPlaceholder='Keine Korrektoren vorhanden.'
-            items={tutors.filter(tutor => tutor.roles.indexOf(Role.CORRECTOR) > -1)}
+            items={tutors}
             {...userConverterFunctions}
             multiple
             isItemSelected={tutor => values['correctors'].indexOf(tutor.id) > -1}

--- a/client/src/hooks/fetching/User.ts
+++ b/client/src/hooks/fetching/User.ts
@@ -6,6 +6,7 @@ import { Role } from 'shared/dist/model/Role';
 import { Tutorial } from 'shared/dist/model/Tutorial';
 import { MailingStatus } from 'shared/dist/model/Mail';
 import { getTutorial } from './Tutorial';
+import { getNameOfEntity } from '../../util/helperFunctions';
 
 async function fetchTutorialsOfUser(user: User): Promise<UserWithFetchedTutorials> {
   const tutorials = await getTutorialsOfUser(user.id);
@@ -20,7 +21,12 @@ export async function getUsers(): Promise<User[]> {
   const response = await axios.get<User[]>('user');
 
   if (response.status === 200) {
-    return response.data;
+    return response.data.sort((a, b) => {
+      const nameOfA = getNameOfEntity(a, { lastNameFirst: true });
+      const nameOfB = getNameOfEntity(b, { lastNameFirst: true });
+
+      return nameOfA.localeCompare(nameOfB);
+    });
   }
 
   return Promise.reject(`Wrong response code (${response.status}).`);

--- a/client/src/view/tutorialmanagement/TutorialManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialManagement.tsx
@@ -3,6 +3,7 @@ import { compareAsc } from 'date-fns';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { HasId } from 'shared/dist/model/Common';
+import { Role } from 'shared/dist/model/Role';
 import { TutorialDTO } from 'shared/dist/model/Tutorial';
 import { User } from 'shared/dist/model/User';
 import TutorialForm, {
@@ -15,7 +16,7 @@ import TableWithForm from '../../components/TableWithForm';
 import { useDialog } from '../../hooks/DialogService';
 import { useAxios } from '../../hooks/FetchingService';
 import { TutorialWithFetchedCorrectors } from '../../typings/types';
-import { getNameOfEntity, getDisplayStringForTutorial } from '../../util/helperFunctions';
+import { getDisplayStringForTutorial, getNameOfEntity } from '../../util/helperFunctions';
 import TutorialTableRow from './components/TutorialTableRow';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -58,7 +59,7 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
   const [tutorials, setTutorials] = useState<TutorialWithFetchedCorrectors[]>([]);
   const [tutors, setTutors] = useState<User[]>([]);
   const {
-    getUsers,
+    getUsersWithRole,
     getAllTutorialsAndFetchCorrectors,
     createTutorialAndFetchCorrectors,
     editTutorialAndFetchCorrectors: editTutorialRequest,
@@ -69,7 +70,7 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
   useEffect(() => {
     setIsLoading(true);
     Promise.all([
-      getUsers().catch(reason => {
+      getUsersWithRole(Role.TUTOR).catch(reason => {
         console.error(reason);
         enqueueSnackbar('Nutzer konnten nicht abgerufen werden.', { variant: 'error' });
       }),
@@ -88,7 +89,7 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
 
       setIsLoading(false);
     });
-  }, [enqueueSnackbar, getUsers, getAllTutorialsAndFetchCorrectors]);
+  }, [enqueueSnackbar, getUsersWithRole, getAllTutorialsAndFetchCorrectors]);
 
   const handleCreateTutorial: TutorialFormSubmitCallback = async (
     values,

--- a/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
@@ -134,8 +134,6 @@ function TutorialSubstituteManagement({ match: { params } }: Props): JSX.Element
       return;
     }
 
-    // TODO: Does not work if tutor was set previously and gets set to '""' (or falsy value in general).
-    //       To solve this problem the editor state propably has to be done in a different way - if not the whole SubstituteDTO part in a way that it allows the tutor property to be 'undefined'.
     const datesOfSubstitutes: { [tutor: string]: string[] } = {};
     const datesWithoutSubstitute: any[] = [];
 
@@ -218,9 +216,9 @@ function TutorialSubstituteManagement({ match: { params } }: Props): JSX.Element
                         name={`substitutes.${selectedDate.toDateString()}`}
                         label='Ersatztutor'
                         emptyPlaceholder='Keine Tutoren vorhanden.'
-                        hasNoneItem
+                        nameOfNoneItem='Keine Vertretung'
                         items={tutors}
-                        itemToString={getNameOfEntity}
+                        itemToString={tutor => getNameOfEntity(tutor, { lastNameFirst: true })}
                         itemToValue={t => t.id}
                       />
                     </>

--- a/server/src/services/tutorial-service/TutorialService.class.ts
+++ b/server/src/services/tutorial-service/TutorialService.class.ts
@@ -226,13 +226,17 @@ class TutorialService {
       }
     }
 
-    for (const date of _.difference(previousDates, newDates)) {
-      tutorial.substitutes.delete(date.toDateString());
-    }
-
     if (substitute) {
+      for (const date of _.difference(previousDates, newDates)) {
+        tutorial.substitutes.delete(date.toDateString());
+      }
+
       for (const date of _.difference(newDates, previousDates)) {
         tutorial.substitutes.set(date.toDateString(), substitute.id);
+      }
+    } else {
+      for (const date of newDates) {
+        tutorial.substitutes.delete(date.toDateString());
       }
     }
 

--- a/server/src/services/tutorial-service/TutorialService.class.ts
+++ b/server/src/services/tutorial-service/TutorialService.class.ts
@@ -209,7 +209,9 @@ class TutorialService {
 
   public async addSubstituteToTutorial(id: string, substDTO: SubstituteDTO): Promise<Tutorial> {
     const tutorial = await this.getDocumentWithID(id);
-    const substitute = await userService.getDocumentWithId(substDTO.tutorId);
+    const substitute = substDTO.tutorId
+      ? await userService.getDocumentWithId(substDTO.tutorId)
+      : undefined;
 
     const newDates: Date[] = substDTO.dates.map(d => new Date(d));
     const previousDates: Date[] = [];
@@ -228,8 +230,10 @@ class TutorialService {
       tutorial.substitutes.delete(date.toDateString());
     }
 
-    for (const date of _.difference(newDates, previousDates)) {
-      tutorial.substitutes.set(date.toDateString(), substitute.id);
+    if (substitute) {
+      for (const date of _.difference(newDates, previousDates)) {
+        tutorial.substitutes.set(date.toDateString(), substitute.id);
+      }
     }
 
     return this.getTutorialOrReject(await tutorial.save());

--- a/shared/src/model/Tutorial.ts
+++ b/shared/src/model/Tutorial.ts
@@ -22,8 +22,8 @@ export interface Tutorial extends HasId {
 }
 
 export interface SubstituteDTO {
+  tutorId?: string;
   dates: string[];
-  tutorId: string;
 }
 
 export interface LoggedInUserTutorial extends HasId {

--- a/shared/src/validators/Tutorial.ts
+++ b/shared/src/validators/Tutorial.ts
@@ -18,7 +18,7 @@ const TutorialDTOSchema = Yup.object().shape<TutorialDTO>({
 });
 
 const SubstituteDTOSchema = Yup.object().shape<SubstituteDTO>({
-  tutorId: Yup.string().required(),
+  tutorId: Yup.string().notRequired(),
   dates: Yup.array<string>().required(),
 });
 


### PR DESCRIPTION
# :ticket: Description
Adds the ability to remove a substitute tutor after he/she was assigned as a substitute. This also includes some changes to more basic components:
- `CustomSelect` can handle a 'none item' which can be used to deselect a selection made.
- `getUsers` returns the users sorted ascending by their names ('lastname, firstname').
<!-- Describe this PR -->

# :lock: Closes
- Closes #97 
- Closes #41 
<!-- Which issue(s) is (are) being closed by the PR? -->
