### PR TITLE
Add ability to set all students to present at once for one day

### DIFF
--- a/client/src/components/forms/components/SubmitButton.tsx
+++ b/client/src/components/forms/components/SubmitButton.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import { CircularProgress, Modal, Tooltip, Typography } from '@material-ui/core';
 import Button, { ButtonProps } from '@material-ui/core/Button';
-import { CircularProgress, Modal, Typography } from '@material-ui/core';
 import { CircularProgressProps } from '@material-ui/core/CircularProgress';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import clsx from 'clsx';
+import React from 'react';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -33,6 +33,7 @@ interface Props extends Omit<ButtonProps, 'type'> {
   isSubmitting: boolean;
   CircularProgressProps?: CircularProgressProps;
   modalText?: string;
+  tooltipText?: string;
 }
 
 function SubmitButton({
@@ -41,25 +42,35 @@ function SubmitButton({
   children,
   disabled,
   modalText,
+  tooltipText,
   ...other
 }: Props): JSX.Element {
   const classes = useStyles();
+  const isDisabled = isSubmitting || disabled;
+
+  const ButtomComp = (
+    <Button {...other} type='submit' disabled={isDisabled}>
+      {isSubmitting && (
+        <CircularProgress
+          size={24}
+          {...CircularProgressProps}
+          className={clsx(
+            CircularProgressProps && CircularProgressProps.className,
+            classes.spinner
+          )}
+        />
+      )}
+
+      {children}
+    </Button>
+  );
   return (
     <>
-      <Button {...other} type='submit' disabled={isSubmitting || disabled}>
-        {isSubmitting && (
-          <CircularProgress
-            size={24}
-            {...CircularProgressProps}
-            className={clsx(
-              CircularProgressProps && CircularProgressProps.className,
-              classes.spinner
-            )}
-          />
-        )}
-
-        {children}
-      </Button>
+      {tooltipText && !isDisabled ? (
+        <Tooltip title={tooltipText}>{ButtomComp}</Tooltip>
+      ) : (
+        ButtomComp
+      )}
 
       <Modal open={!!modalText && isSubmitting} className={classes.modal}>
         <div className={classes.modalContent} tabIndex={-1}>

--- a/client/src/hooks/fetching/Tutorial.ts
+++ b/client/src/hooks/fetching/Tutorial.ts
@@ -1,5 +1,6 @@
 import { Student } from 'shared/dist/model/Student';
 import { SubstituteDTO, Tutorial, TutorialDTO } from 'shared/dist/model/Tutorial';
+import { sortByName } from 'shared/dist/util/helpers';
 import { User, TutorInfo } from 'shared/dist/model/User';
 import {
   StudentByTutorialSlotSummaryMap,
@@ -184,7 +185,7 @@ export async function getStudentsOfTutorial(id: string): Promise<Student[]> {
   const response = await axios.get<Student[]>(`tutorial/${id}/student`);
 
   if (response.status === 200) {
-    return response.data;
+    return response.data.sort(sortByName);
   }
 
   return Promise.reject(`Wrong response code (${response.status}).`);

--- a/client/src/hooks/fetching/User.ts
+++ b/client/src/hooks/fetching/User.ts
@@ -6,7 +6,7 @@ import { Role } from 'shared/dist/model/Role';
 import { Tutorial } from 'shared/dist/model/Tutorial';
 import { MailingStatus } from 'shared/dist/model/Mail';
 import { getTutorial } from './Tutorial';
-import { getNameOfEntity } from '../../util/helperFunctions';
+import { sortByName } from 'shared/dist/util/helpers';
 
 async function fetchTutorialsOfUser(user: User): Promise<UserWithFetchedTutorials> {
   const tutorials = await getTutorialsOfUser(user.id);
@@ -21,12 +21,7 @@ export async function getUsers(): Promise<User[]> {
   const response = await axios.get<User[]>('user');
 
   if (response.status === 200) {
-    return response.data.sort((a, b) => {
-      const nameOfA = getNameOfEntity(a, { lastNameFirst: true });
-      const nameOfB = getNameOfEntity(b, { lastNameFirst: true });
-
-      return nameOfA.localeCompare(nameOfB);
-    });
+    return response.data.sort(sortByName);
   }
 
   return Promise.reject(`Wrong response code (${response.status}).`);

--- a/client/src/util/helperFunctions.ts
+++ b/client/src/util/helperFunctions.ts
@@ -4,26 +4,6 @@ import { PointMap } from 'shared/dist/model/Points';
 import { ScheinExam } from 'shared/dist/model/Scheinexam';
 import { Student } from 'shared/dist/model/Student';
 
-interface EntityWithName {
-  lastname: string;
-  firstname: string;
-}
-
-interface NameOptions {
-  lastNameFirst: boolean;
-}
-
-export function getNameOfEntity(
-  entity: EntityWithName,
-  options: Partial<NameOptions> = {}
-): string {
-  if (options.lastNameFirst) {
-    return `${entity.lastname}, ${entity.firstname} `;
-  } else {
-    return `${entity.firstname} ${entity.lastname}`;
-  }
-}
-
 export function getDisplayStringForTutorial(tutorial: { slot: string }): string {
   return `Tutorium ${tutorial.slot.padStart(2, '0')}`;
 }

--- a/client/src/view/pointsmanagement/ScheinExamPointEntry.tsx
+++ b/client/src/view/pointsmanagement/ScheinExamPointEntry.tsx
@@ -7,9 +7,10 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import { PointMap, UpdatePointsDTO } from 'shared/dist/model/Points';
 import { ScheinExam } from 'shared/dist/model/Scheinexam';
 import { Student } from 'shared/dist/model/Student';
+import { getNameOfEntity } from 'shared/dist/util/helpers';
 import CustomSelect from '../../components/CustomSelect';
 import { useAxios } from '../../hooks/FetchingService';
-import { getDisplayStringOfScheinExam, getNameOfEntity } from '../../util/helperFunctions';
+import { getDisplayStringOfScheinExam } from '../../util/helperFunctions';
 import PointsCard, {
   convertPointsCardFormStateToDTO,
   PointsSaveCallback,

--- a/client/src/view/pointsmanagement/components/EditStudentPointsDialogContent.tsx
+++ b/client/src/view/pointsmanagement/components/EditStudentPointsDialogContent.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import { PointMap } from 'shared/dist/model/Points';
 import { Sheet } from 'shared/dist/model/Sheet';
 import { Team } from 'shared/dist/model/Team';
+import { getNameOfEntity } from 'shared/dist/util/helpers';
 import SubmitButton from '../../../components/forms/components/SubmitButton';
 import { FormikSubmitCallback } from '../../../types';
-import { getNameOfEntity } from '../../../util/helperFunctions';
 import PointsCard, {
   getInitialPointsCardValues,
   PointsCardFormState,

--- a/client/src/view/studentmanagement/Studentmanagement.tsx
+++ b/client/src/view/studentmanagement/Studentmanagement.tsx
@@ -6,13 +6,13 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import { ScheinCriteriaSummary } from 'shared/dist/model/ScheinCriteria';
 import { StudentDTO } from 'shared/dist/model/Student';
 import { Team } from 'shared/dist/model/Team';
+import { getNameOfEntity } from 'shared/dist/util/helpers';
 import StudentForm, { StudentFormSubmitCallback } from '../../components/forms/StudentForm';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import TableWithForm from '../../components/TableWithForm';
 import { useDialog } from '../../hooks/DialogService';
 import { useAxios } from '../../hooks/FetchingService';
 import { StudentWithFetchedTeam } from '../../typings/types';
-import { getNameOfEntity } from '../../util/helperFunctions';
 import ExtendableStudentRow from '../management/components/ExtendableStudentRow';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -69,13 +69,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
       getScheinCriteriaSummariesOfAllStudentsOfTutorial(params.tutorialId).then(response =>
         setSummaries(response)
       );
-      setStudents(
-        studentsResponse.sort((a, b) =>
-          getNameOfEntity(a, { lastNameFirst: true }).localeCompare(
-            getNameOfEntity(b, { lastNameFirst: true })
-          )
-        )
-      );
+      setStudents(studentsResponse);
       setTeams(teams);
       setIsLoading(false);
     })();

--- a/client/src/view/tutorialmanagement/TutorialManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialManagement.tsx
@@ -6,6 +6,7 @@ import { HasId } from 'shared/dist/model/Common';
 import { Role } from 'shared/dist/model/Role';
 import { TutorialDTO } from 'shared/dist/model/Tutorial';
 import { User } from 'shared/dist/model/User';
+import { getNameOfEntity } from 'shared/dist/util/helpers';
 import TutorialForm, {
   getInitialTutorialFormValues,
   TutorialFormState,
@@ -16,7 +17,7 @@ import TableWithForm from '../../components/TableWithForm';
 import { useDialog } from '../../hooks/DialogService';
 import { useAxios } from '../../hooks/FetchingService';
 import { TutorialWithFetchedCorrectors } from '../../typings/types';
-import { getDisplayStringForTutorial, getNameOfEntity } from '../../util/helperFunctions';
+import { getDisplayStringForTutorial } from '../../util/helperFunctions';
 import TutorialTableRow from './components/TutorialTableRow';
 
 const useStyles = makeStyles((theme: Theme) =>

--- a/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
@@ -6,9 +6,11 @@ import { Formik } from 'formik';
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Role } from 'shared/dist/model/Role';
-import { Tutorial, SubstituteDTO } from 'shared/dist/model/Tutorial';
+import { SubstituteDTO, Tutorial } from 'shared/dist/model/Tutorial';
 import { User } from 'shared/dist/model/User';
+import { getNameOfEntity } from 'shared/dist/util/helpers';
 import { renderLink } from '../../components/drawer/components/renderLink';
+import FormikDebugDisplay from '../../components/forms/components/FormikDebugDisplay';
 import FormikMultipleDatesPicker, {
   DateClickedHandler,
   getDateString,
@@ -17,13 +19,8 @@ import FormikSelect from '../../components/forms/components/FormikSelect';
 import SubmitButton from '../../components/forms/components/SubmitButton';
 import { useAxios } from '../../hooks/FetchingService';
 import { FormikSubmitCallback } from '../../types';
-import {
-  getDisplayStringForTutorial,
-  getNameOfEntity,
-  parseDateToMapKey,
-} from '../../util/helperFunctions';
+import { getDisplayStringForTutorial, parseDateToMapKey } from '../../util/helperFunctions';
 import { RoutingPath } from '../../util/RoutingPath';
-import FormikDebugDisplay from '../../components/forms/components/FormikDebugDisplay';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/client/src/view/usermanagement/UserManagement.tsx
+++ b/client/src/view/usermanagement/UserManagement.tsx
@@ -5,15 +5,16 @@ import { MailingStatus } from 'shared/dist/model/Mail';
 import { Role } from 'shared/dist/model/Role';
 import { Tutorial } from 'shared/dist/model/Tutorial';
 import { CreateUserDTO, UserDTO } from 'shared/dist/model/User';
+import { getNameOfEntity } from 'shared/dist/util/helpers';
 import SubmitButton from '../../components/forms/components/SubmitButton';
-import UserForm, { UserFormSubmitCallback, UserFormState } from '../../components/forms/UserForm';
+import UserForm, { UserFormState, UserFormSubmitCallback } from '../../components/forms/UserForm';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import SnackbarWithList from '../../components/SnackbarWithList';
 import TableWithForm from '../../components/TableWithForm';
 import { useDialog } from '../../hooks/DialogService';
 import { useAxios } from '../../hooks/FetchingService';
 import { UserWithFetchedTutorials } from '../../typings/types';
-import { getNameOfEntity, saveBlob } from '../../util/helperFunctions';
+import { saveBlob } from '../../util/helperFunctions';
 import UserTableRow from './components/UserTableRow';
 
 const useStyles = makeStyles((theme: Theme) =>

--- a/server/src/services/pdf-service/PdfService.class.ts
+++ b/server/src/services/pdf-service/PdfService.class.ts
@@ -20,6 +20,7 @@ import tutorialService from '../tutorial-service/TutorialService.class';
 import userService from '../user-service/UserService.class';
 import githubMarkdownCSS from './css/githubMarkdown';
 import { PointMap } from 'shared/dist/model/Points';
+import { getNameOfEntity, sortByName } from 'shared/dist/util/helpers';
 
 interface StudentData {
   matriculationNo: string;
@@ -243,6 +244,7 @@ class PdfService {
     const students: Student[] = await Promise.all(
       tutorial.students.map(student => studentService.getStudentWithId(student))
     );
+    students.sort(sortByName);
     // const substitutePart = isSubstituteTutor(tutorial, userData)
     //   ? `, Ersatztutor: ${getNameOfEntity(userData)}`
     //   : '';
@@ -252,7 +254,9 @@ class PdfService {
     const rows: string = students
       .map(
         student =>
-          `<tr><td>${student.lastname}, ${student.firstname}</td><td width="50%"></td></tr>`
+          `<tr><td>${getNameOfEntity(student, {
+            lastNameFirst: true,
+          })}</td><td width="50%"></td></tr>`
       )
       .join('');
 

--- a/shared/src/util/helpers.ts
+++ b/shared/src/util/helpers.ts
@@ -1,0 +1,20 @@
+import { NamedElement } from '../model/Common';
+
+interface NameOptions {
+  lastNameFirst: boolean;
+}
+
+export function getNameOfEntity(entity: NamedElement, options: Partial<NameOptions> = {}): string {
+  if (options.lastNameFirst) {
+    return `${entity.lastname}, ${entity.firstname} `;
+  } else {
+    return `${entity.firstname} ${entity.lastname}`;
+  }
+}
+
+export function sortByName(a: NamedElement, b: NamedElement): number {
+  const nameOfA = getNameOfEntity(a, { lastNameFirst: true });
+  const nameOfB = getNameOfEntity(b, { lastNameFirst: true });
+
+  return nameOfA.localeCompare(nameOfB);
+}


### PR DESCRIPTION
# :ticket: Description
Adds a button to the attendance page with which one can set all students to `PRESENT` if they don't have an `AttendanceState` already.

This PR also fixes / changes some small things:
- Fix attendance PDF not being sorted by name.
- Move `getNameOfEntity` function to the shared/ package.
- Sort students after fetching them in tutorial.
<!-- Describe this PR -->

# :lock: Closes
- Closes #76 
<!-- Which issue(s) is (are) being closed by the PR? -->
