### PR TITLE
Fix for inconsistent student-team state

### DIFF
--- a/client/src/components/forms/StudentForm.tsx
+++ b/client/src/components/forms/StudentForm.tsx
@@ -59,7 +59,7 @@ interface StudentFormState {
 interface Props extends Omit<FormikBaseFormProps<StudentFormState>, CommonlyUsedFormProps> {
   onSubmit: StudentFormSubmitCallback;
   student?: StudentWithFetchedTeam;
-  students: StudentWithFetchedTeam[];
+  otherStudents: StudentWithFetchedTeam[];
   teams: Team[];
   disableTeamDropdown?: boolean;
 }
@@ -134,7 +134,7 @@ function StudentForm({
   onSubmit,
   className,
   student,
-  students,
+  otherStudents,
   disableTeamDropdown,
   ...other
 }: Props): JSX.Element {
@@ -179,7 +179,7 @@ function StudentForm({
                   return undefined;
                 }
 
-                for (const s of students) {
+                for (const s of otherStudents) {
                   if (s.matriculationNo && value === s.matriculationNo) {
                     return `Matrikelnummer wird bereits von ${getNameOfEntity(s)} verwendet.`;
                   }

--- a/client/src/hooks/fetching/Student.ts
+++ b/client/src/hooks/fetching/Student.ts
@@ -153,7 +153,14 @@ export async function fetchTeamsOfStudents(students: Student[]): Promise<Student
   const promises: Promise<StudentWithFetchedTeam>[] = [];
 
   for (const student of students) {
-    promises.push(getTeamOfStudent(student).then(team => ({ ...student, team })));
+    promises.push(
+      getTeamOfStudent(student)
+        .then(team => ({ ...student, team }))
+        .catch(() => {
+          console.log('Could not load team of student.');
+          return { ...student, team: undefined };
+        })
+    );
   }
 
   return Promise.all(promises);

--- a/client/src/view/studentmanagement/AllStudentsAdminView.tsx
+++ b/client/src/view/studentmanagement/AllStudentsAdminView.tsx
@@ -169,7 +169,7 @@ function AllStudentsAdminView({ enqueueSnackbar }: PropType): JSX.Element {
       content: (
         <StudentForm
           student={student}
-          students={students}
+          otherStudents={students.filter(s => s.id !== student.id)}
           teams={student.team ? [student.team] : []}
           onSubmit={editStudent(student)}
           onCancelClicked={() => dialog.hide()}

--- a/client/src/view/studentmanagement/Studentmanagement.tsx
+++ b/client/src/view/studentmanagement/Studentmanagement.tsx
@@ -237,7 +237,9 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
         <TableWithForm
           title='Neuen Studierenden anlegen'
           placeholder='Keine Studierenden vorhanden.'
-          form={<StudentForm teams={teams} otherStudents={students} onSubmit={handleCreateStudent} />}
+          form={
+            <StudentForm teams={teams} otherStudents={students} onSubmit={handleCreateStudent} />
+          }
           items={students}
           createRowFromItem={student => (
             <ExtendableStudentRow

--- a/client/src/view/studentmanagement/Studentmanagement.tsx
+++ b/client/src/view/studentmanagement/Studentmanagement.tsx
@@ -201,7 +201,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
       content: (
         <StudentForm
           student={student}
-          students={students}
+          otherStudents={students.filter(s => s.id !== student.id)}
           teams={teams}
           onSubmit={editStudent(student)}
           onCancelClicked={() => dialog.hide()}
@@ -237,7 +237,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
         <TableWithForm
           title='Neuen Studierenden anlegen'
           placeholder='Keine Studierenden vorhanden.'
-          form={<StudentForm teams={teams} students={students} onSubmit={handleCreateStudent} />}
+          form={<StudentForm teams={teams} otherStudents={students} onSubmit={handleCreateStudent} />}
           items={students}
           createRowFromItem={student => (
             <ExtendableStudentRow

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
+    volumes: 
+      - db_data:/data/db
 
   mongo-express:
     container_name: mongo_express
@@ -40,7 +42,7 @@ services:
       - ./server/config:/tms/server/config
 
 volumes:
-  db-data:
+  db_data:
 
 networks:
   tms_db:

--- a/server/src/model/documents/StudentDocument.ts
+++ b/server/src/model/documents/StudentDocument.ts
@@ -1,11 +1,11 @@
 import {
   instanceMethod,
+  InstanceType,
   mapProp,
   plugin,
   prop,
   Ref,
   Typegoose,
-  InstanceType,
 } from '@hasezoey/typegoose';
 import { Document, Model, Types } from 'mongoose';
 import { fieldEncryption } from 'mongoose-field-encryption';
@@ -18,7 +18,7 @@ import Logger from '../../helpers/Logger';
 import teamService from '../../services/team-service/TeamService.class';
 import { CollectionName } from '../CollectionName';
 import { AttendanceDocument, AttendanceSchema } from './AttendanceDocument';
-import { TeamDocument, TeamSchema } from './TeamDocument';
+import { TeamDocument } from './TeamDocument';
 import { TutorialDocument } from './TutorialDocument';
 
 @plugin(fieldEncryption, {

--- a/server/src/model/documents/StudentDocument.ts
+++ b/server/src/model/documents/StudentDocument.ts
@@ -1,4 +1,12 @@
-import { instanceMethod, mapProp, plugin, prop, Ref, Typegoose } from '@hasezoey/typegoose';
+import {
+  instanceMethod,
+  mapProp,
+  plugin,
+  prop,
+  Ref,
+  Typegoose,
+  InstanceType,
+} from '@hasezoey/typegoose';
 import { Document, Model, Types } from 'mongoose';
 import { fieldEncryption } from 'mongoose-field-encryption';
 import { PointId, PointMap, PointMapDTO, PointMapEntry } from 'shared/dist/model/Points';
@@ -6,10 +14,11 @@ import { Sheet } from 'shared/dist/model/Sheet';
 import { Student } from 'shared/dist/model/Student';
 import databaseConfig from '../../helpers/database';
 import { getIdOfDocumentRef } from '../../helpers/documentHelpers';
+import Logger from '../../helpers/Logger';
 import teamService from '../../services/team-service/TeamService.class';
 import { CollectionName } from '../CollectionName';
 import { AttendanceDocument, AttendanceSchema } from './AttendanceDocument';
-import { TeamDocument } from './TeamDocument';
+import { TeamDocument, TeamSchema } from './TeamDocument';
 import { TutorialDocument } from './TutorialDocument';
 
 @plugin(fieldEncryption, {
@@ -67,26 +76,38 @@ export class StudentSchema extends Typegoose
   cakeCount!: number;
 
   @instanceMethod
-  async getTeam(): Promise<TeamDocument> {
+  async getTeam(this: InstanceType<StudentSchema>): Promise<TeamDocument | undefined> {
     if (!this.team) {
-      throw new Error('Can not get team because this student does not belong to a team.');
+      return undefined;
     }
 
-    const [team] = await teamService.getDocumentWithId(
-      getIdOfDocumentRef(this.tutorial),
-      getIdOfDocumentRef(this.team)
-    );
+    try {
+      const [team] = await teamService.getDocumentWithId(
+        getIdOfDocumentRef(this.tutorial),
+        getIdOfDocumentRef(this.team)
+      );
 
-    return team;
+      return team;
+    } catch {
+      Logger.error(
+        `[StudentDocument] Team with ID ${this.team.toString()} does not exist in the DB (anymore). It gets removed from the student.`
+      );
+
+      this.team = undefined;
+      await this.save();
+
+      return undefined;
+    }
   }
 
   @instanceMethod
-  async getPoints(): Promise<PointMap> {
-    if (!this.team) {
+  async getPoints(this: InstanceType<StudentSchema>): Promise<PointMap> {
+    const team = await this.getTeam();
+
+    if (!team) {
       return new PointMap(this.points);
     }
 
-    const team = await this.getTeam();
     const points = new PointMap();
     const pointsOfTeam = new PointMap(team.points);
     const ownPoints = new PointMap(this.points);
@@ -103,7 +124,10 @@ export class StudentSchema extends Typegoose
   }
 
   @instanceMethod
-  async getPointEntry(id: PointId): Promise<PointMapEntry | undefined> {
+  async getPointEntry(
+    this: InstanceType<StudentSchema>,
+    id: PointId
+  ): Promise<PointMapEntry | undefined> {
     const ownMap = new PointMap(this.points);
     const entry = ownMap.getPointEntry(id);
 
@@ -111,18 +135,19 @@ export class StudentSchema extends Typegoose
       return entry;
     }
 
-    if (!this.team) {
+    const team = await this.getTeam();
+
+    if (!team) {
       return undefined;
     }
 
-    const team = await this.getTeam();
     const teamEntry = new PointMap(team.points).getPointEntry(id);
 
     return teamEntry;
   }
 
   @instanceMethod
-  async getPointsOfExercise(id: PointId): Promise<number> {
+  async getPointsOfExercise(this: InstanceType<StudentSchema>, id: PointId): Promise<number> {
     const entry = await this.getPointEntry(id);
 
     return entry ? PointMap.getPointsOfEntry(entry) : 0;

--- a/server/src/services/team-service/TeamService.class.ts
+++ b/server/src/services/team-service/TeamService.class.ts
@@ -217,7 +217,7 @@ class TeamService {
       return;
     }
 
-    if (student.team) {
+    if (await student.getTeam()) {
       await this.removeStudentAsMemberFromTeam(student, { saveStudent: false });
     }
 
@@ -235,14 +235,15 @@ class TeamService {
     student: StudentDocument,
     { saveStudent }: { saveStudent?: boolean } = {}
   ) {
-    if (!student.team) {
+    const oldTeam = await student.getTeam();
+
+    if (!oldTeam) {
       return;
     }
 
-    const [oldTeam, tutorial] = await this.getDocumentWithId(
-      getIdOfDocumentRef(student.tutorial),
-      getIdOfDocumentRef(student.team)
-    );
+    const tutorial = isDocument(oldTeam.tutorial)
+      ? oldTeam.tutorial
+      : await tutorialService.getDocumentWithID(oldTeam.tutorial.toString());
 
     await studentService.movePointsFromTeamToStudent(student);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "module": "commonjs"
-  }
-}


### PR DESCRIPTION
# :ticket: Description
Adds the ability to the server to recover from an inconsistent state regarding students and their teams: If a student is assigned to a team that does not exist the server will remove that team and return the student without it.

This also adds a catch to the fetching function for the team of a student in the client to prevent full crashes if a team could not be found.
<!-- Describe this PR -->