### PR TITLE
Fixes no dates in substitute attendance dropdown available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 # Tell the PDFService where to find the Chrome executable.
 ENV TMS_PUPPETEER_EXEC_PATH "/usr/bin/chromium-browser"
 
-# Puppeteer v1.17.0 works with Chromium 76.
-RUN yarn add puppeteer@1.17.0
+# Puppeteer v1.17.0 works with Chromium 77.
+RUN yarn add puppeteer@1.19.0
 
 # Add user so we don't need --no-sandbox.
 RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN yarn build
 # Create the image which runs the server
 #
 # =============================================
-FROM alpine:edge
+FROM alpine:3
 
 # Installs latest Chromium (76) package.
 RUN apk add --no-cache \
@@ -36,7 +36,7 @@ RUN apk add --no-cache \
       ca-certificates \
       ttf-freefont \
       terminus-font \
-      nodejs \
+      nodejs-current \
       yarn 
 
 COPY --from=build tms/server/build tms/server

--- a/client/src/components/forms/TutorialForm.tsx
+++ b/client/src/components/forms/TutorialForm.tsx
@@ -130,7 +130,9 @@ export function getInitialTutorialFormValues(
     };
   }
 
-  const sortedDates: Date[] = tutorial.dates.sort((a, b) => a.getTime() - b.getTime());
+  const sortedDates: Date[] = tutorial.dates
+    .sort((a, b) => new Date(a).getTime() - new Date(b).getTime())
+    .map(d => new Date(d));
 
   return {
     slot: tutorial.slot,
@@ -142,7 +144,7 @@ export function getInitialTutorialFormValues(
     startTime: tutorial.startTime.toISOString(),
     endTime: tutorial.endTime.toISOString(),
     correctors: tutorial.correctors.map(corrector => corrector.id),
-    selectedDates: tutorial.dates.map(date => date.toDateString()),
+    selectedDates: tutorial.dates.map(date => new Date(date).toDateString()),
   };
 }
 

--- a/client/src/util/axiosTransforms.ts
+++ b/client/src/util/axiosTransforms.ts
@@ -51,19 +51,16 @@ export function transformMultipleTutorialResponse(responseJSON: string): Tutoria
 }
 
 export function transformTutorialResponse(responseJSON: string): Tutorial {
-  // FIXME: Crashed if responseJSON is empty.
+  // FIXME: Crashes if responseJSON is empty.
   const {
-    dates: dateStrings,
+    dates,
     startTime: startTimeString,
     endTime: endTimeString,
     ...rest
   }: TutorialResponse = JSON.parse(responseJSON);
-  const dates: Date[] = [];
 
   const startTime = new Date(startTimeString);
   const endTime = new Date(endTimeString);
-
-  dateStrings.forEach(date => dates.push(new Date(date)));
 
   return {
     ...rest,

--- a/client/src/util/axiosTransforms.ts
+++ b/client/src/util/axiosTransforms.ts
@@ -22,11 +22,10 @@ export function transformLoggedInUserResponse(responseJSON: string): LoggedInUse
 
   substituteTutorials.forEach(tutorial => {
     const { dates, ...other } = tutorial;
-    const parsedDates: Date[] = dates.map(d => new Date(d));
 
     parsedSubstituteTutorials.push({
       ...other,
-      dates: parsedDates,
+      dates,
     });
   });
 

--- a/client/src/view/attendance/AttendanceManager.tsx
+++ b/client/src/view/attendance/AttendanceManager.tsx
@@ -61,13 +61,16 @@ function getAvailableDates(
     const substituteTutorial = user.substituteTutorials.find(sub => sub.id === tutorial.id);
 
     if (substituteTutorial) {
-      return tutorial.dates.filter(
-        date => substituteTutorial.dates.findIndex(d => isSameDay(date, new Date(d))) !== -1
-      );
+      return tutorial.dates
+        .filter(
+          date =>
+            substituteTutorial.dates.findIndex(d => isSameDay(new Date(date), new Date(d))) !== -1
+        )
+        .map(d => new Date(d));
     }
   }
 
-  return tutorial.dates;
+  return tutorial.dates.map(d => new Date(d));
 }
 
 function AttendanceManager({ tutorial: tutorialFromProps }: Props): JSX.Element {

--- a/client/src/view/attendance/AttendanceManager.tsx
+++ b/client/src/view/attendance/AttendanceManager.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '@material-ui/core';
 import GREEN from '@material-ui/core/colors/green';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { compareAsc, format } from 'date-fns';
+import { format, isSameDay } from 'date-fns';
 import { useSnackbar } from 'notistack';
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import { Attendance, AttendanceDTO, AttendanceState } from 'shared/dist/model/Attendance';
@@ -62,7 +62,7 @@ function getAvailableDates(
 
     if (substituteTutorial) {
       return tutorial.dates.filter(
-        date => substituteTutorial.dates.findIndex(d => compareAsc(date, d) === 0) !== -1
+        date => substituteTutorial.dates.findIndex(d => isSameDay(date, new Date(d))) !== -1
       );
     }
   }

--- a/client/src/view/dashboard/components/TutorialStatsCard.tsx
+++ b/client/src/view/dashboard/components/TutorialStatsCard.tsx
@@ -64,7 +64,7 @@ function TutorialStatsCard({ value }: TutorialStatsCardProps): JSX.Element {
             <TableRow>
               <TableCell className={classes.tableTitle}>Wochentag: </TableCell>
               <TableCell>
-                {value.tutorial.dates[0].toLocaleString('de-de', { weekday: 'long' })}
+                {new Date(value.tutorial.dates[0]).toLocaleString('de-de', { weekday: 'long' })}
               </TableCell>
             </TableRow>
           </>

--- a/client/src/view/pointsmanagement/ScheinExamManagement.tsx
+++ b/client/src/view/pointsmanagement/ScheinExamManagement.tsx
@@ -36,7 +36,7 @@ function generateScheinExamDTO(values: ScheinExamFormState): ScheinExamDTO {
     scheinExamNo: Number.parseFloat(values.scheinExamNo),
     exercises: convertFormExercisesToDTOs(values.exercises),
     percentageNeeded: values.percentageNeeded,
-    date: date.toISOString(),
+    date: date.toDateString(),
   };
 }
 

--- a/client/src/view/studentmanagement/AllStudentsAdminView.tsx
+++ b/client/src/view/studentmanagement/AllStudentsAdminView.tsx
@@ -98,6 +98,7 @@ function AllStudentsAdminView({ enqueueSnackbar }: PropType): JSX.Element {
     getAllStudentsAndFetchTeams,
     getAllTutorials,
     getScheinCriteriaSummaryOfAllStudents,
+    enqueueSnackbar,
   ]);
 
   async function printOverviewSheet() {

--- a/client/src/view/studentmanagement/Studentmanagement.tsx
+++ b/client/src/view/studentmanagement/Studentmanagement.tsx
@@ -94,6 +94,7 @@ function Studentoverview({ match: { params }, enqueueSnackbar }: PropType): JSX.
     getTeamsOfTutorial,
     getScheinCriteriaSummariesOfAllStudentsOfTutorial,
     tutorialId,
+    enqueueSnackbar,
   ]);
 
   async function createTeamIfNeccessary(team: string | undefined): Promise<string | undefined> {

--- a/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
@@ -150,7 +150,7 @@ function TutorialSubstituteManagement({ match: { params } }: Props): JSX.Element
 
     const noSubDTO: SubstituteDTO = {
       tutorId: undefined,
-      dates: datesWithoutSubstitute.map(d => new Date(d).toISOString()),
+      dates: datesWithoutSubstitute.map(d => new Date(d).toDateString()),
     };
 
     let response: Tutorial | undefined = await setSubstituteTutor(tutorial.id, noSubDTO);
@@ -158,7 +158,7 @@ function TutorialSubstituteManagement({ match: { params } }: Props): JSX.Element
     for (const [tutor, dates] of Object.entries(datesOfSubstitutes)) {
       const dto: SubstituteDTO = {
         tutorId: tutor,
-        dates: dates.map(d => new Date(d).toISOString()),
+        dates: dates.map(d => new Date(d).toDateString()),
       };
 
       response = await setSubstituteTutor(tutorial.id, dto);

--- a/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
+++ b/client/src/view/tutorialmanagement/TutorialSubstituteManagement.tsx
@@ -86,10 +86,14 @@ function getInitialValues(tutorial?: Tutorial): TutorialSubstituteFormState {
     };
   }
 
-  const dates = tutorial.dates.sort((a, b) => compareAsc(a, b)).map(date => date.toDateString());
+  const dates = tutorial.dates
+    .sort((a, b) => compareAsc(new Date(a), new Date(b)))
+    .map(date => new Date(date).toDateString());
+
   const substitutes: { [key: string]: string } = {};
 
-  tutorial.dates.forEach(date => {
+  tutorial.dates.forEach(d => {
+    const date = new Date(d);
     substitutes[date.toDateString()] = tutorial.substitutes[parseDateToMapKey(date)] || '';
   });
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts:check:shared": "echo Type checking shared && cd ./shared && yarn ts:check",
     "copy:app": "copyfiles -u 2 -E -V \"client/build/**/*\" server/build/app",
     "docker:build": "yarn version && ts-node ./build-docker-image.ts",
-    "docker:build:pre": "yarn version && ts-node ./build-docker-image.ts --pre",
+    "docker:build:pre": "yarn version && ts-node ./build-docker-image.ts --pre --skip-bundle",
     "upgrade-pkg": "yarn upgrade-pgk:client && yarn upgrade-pgk:server && yarn upgrade-pgk:shared",
     "upgrade-pgk:client": "cd ./client && npm-upgrade",
     "upgrade-pgk:server": "cd ./server && npm-upgrade",

--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
     "nodemailer": "^6.3.1",
     "passport": "^0.4.0",
     "passport-http": "^0.3.0",
-    "puppeteer": "1.17.0",
+    "puppeteer": "1.19.0",
     "reflect-metadata": "^0.1.13",
     "shared": "1.0.0",
     "showdown": "^1.9.0",

--- a/server/src/model/documents/TutorialDocument.ts
+++ b/server/src/model/documents/TutorialDocument.ts
@@ -18,7 +18,8 @@ import studentService from '../../services/student-service/StudentService.class'
 import Logger from '../../helpers/Logger';
 
 export class TutorialSchema extends Typegoose
-  implements Omit<Tutorial, 'id' | 'tutor' | 'correctors' | 'students' | 'teams' | 'substitutes'> {
+  implements
+    Omit<Tutorial, 'id' | 'tutor' | 'correctors' | 'students' | 'teams' | 'substitutes' | 'dates'> {
   @prop({ required: true })
   slot!: string;
 

--- a/server/src/model/dtos/LoggedInUserDTO.ts
+++ b/server/src/model/dtos/LoggedInUserDTO.ts
@@ -16,12 +16,12 @@ export class LoggedInUserTutorialDTO implements LoggedInUserTutorial {
 
 export class LoggedInUserSubstituteTutorialDTO extends LoggedInUserTutorialDTO
   implements LoggedInUserSubstituteTutorial {
-  readonly dates: Date[];
+  readonly dates: string[];
 
   constructor(tutorial: Pick<TutorialDocument, 'id' | 'slot'>, dates: Date[]) {
     super(tutorial);
 
-    this.dates = dates;
+    this.dates = dates.map(date => date.toDateString());
   }
 }
 

--- a/server/src/services/tutorial-service/TutorialService.class.ts
+++ b/server/src/services/tutorial-service/TutorialService.class.ts
@@ -1,11 +1,10 @@
+import { isDocument, Ref } from '@hasezoey/typegoose';
 import { parse } from 'date-fns';
 import _ from 'lodash';
 import { Types } from 'mongoose';
 import { Student } from 'shared/dist/model/Student';
 import { SubstituteDTO, Tutorial, TutorialDTO } from 'shared/dist/model/Tutorial';
-import { User, TutorInfo } from 'shared/dist/model/User';
-import { Ref } from '@hasezoey/typegoose';
-import { isDocument } from '@hasezoey/typegoose';
+import { TutorInfo, User } from 'shared/dist/model/User';
 import { getIdOfDocumentRef } from '../../helpers/documentHelpers';
 import { TypegooseDocument } from '../../helpers/typings';
 import { StudentDocument } from '../../model/documents/StudentDocument';
@@ -270,10 +269,10 @@ class TutorialService {
       id: _id,
       slot,
       tutor: tutor ? getIdOfDocumentRef(tutor) : undefined,
-      dates: dates.map(d => new Date(d)),
+      dates: dates.map(d => d.toDateString()),
       correctors: correctors.map(getIdOfDocumentRef),
-      startTime: new Date(startTime),
-      endTime: new Date(endTime),
+      startTime,
+      endTime,
       students: students.map(getIdOfDocumentRef),
       teams: teams.map(getIdOfDocumentRef),
       substitutes: parsedSubstitutes,

--- a/shared/src/model/Tutorial.ts
+++ b/shared/src/model/Tutorial.ts
@@ -12,7 +12,7 @@ export interface TutorialDTO {
 export interface Tutorial extends HasId {
   slot: string;
   tutor?: string;
-  dates: Date[];
+  dates: string[];
   startTime: Date;
   endTime: Date;
   students: string[];

--- a/shared/src/model/Tutorial.ts
+++ b/shared/src/model/Tutorial.ts
@@ -31,5 +31,5 @@ export interface LoggedInUserTutorial extends HasId {
 }
 
 export interface LoggedInUserSubstituteTutorial extends LoggedInUserTutorial {
-  dates: Date[];
+  dates: string[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,6 +1517,14 @@
     "@types/mongodb" "*"
     "@types/node" "*"
 
+"@types/mongoose@^5.5.21":
+  version "5.5.23"
+  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.5.23.tgz#d2fda27aefc8472684d9d4fdd61c76e83544efd9"
+  integrity sha512-IMij4GufpdQ53FB+S/6KlkAWvFvqLXQNwWsfJOeuKLC9T0OynOSRUMj/LAwMcezZCCUXHBephSNsS3teg0dc/g==
+  dependencies:
+    "@types/mongodb" "*"
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^12.0.2", "@types/node@^12.11.1":
   version "12.11.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.1.tgz#1fd7b821f798b7fa29f667a1be8f3442bb8922a3"
@@ -9465,10 +9473,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.17.0.tgz#371957d227a2f450fa74b78e78a2dadb2be7f14f"
-  integrity sha512-3EXZSximCzxuVKpIHtyec8Wm2dWZn1fc5tQi34qWfiUgubEVYHjUvr0GOJojqf3mifI6oyKnCdrGxaOI+lWReA==
+puppeteer@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.19.0.tgz#e3b7b448c2c97933517078d7a2c53687361bebea"
+  integrity sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
# :ticket: Description
Fixes issues in the code regarding substitutes not having access to the dates of the tutorial.

This also updates puppeteer to 1.19.0 due to the fact that the alpine package of chromium got updated to version 77 aswell. 
<!-- Describe this PR -->

# :lock: Closes
- Closes #137 
<!-- Which issue(s) is (are) being closed by the PR? -->
