### PR TITLE
Add version indicator to server log and client page

### DIFF
--- a/client/src/components/drawer/Drawer.tsx
+++ b/client/src/components/drawer/Drawer.tsx
@@ -1,13 +1,22 @@
-import { Divider, Drawer as MuiDrawer, List, ListSubheader } from '@material-ui/core';
+import {
+  Divider,
+  Drawer as MuiDrawer,
+  List,
+  ListSubheader,
+  Typography,
+  Link,
+} from '@material-ui/core';
 import { DrawerProps } from '@material-ui/core/Drawer';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { OpenInNew as ExternalLinkIcon } from '@material-ui/icons';
 import clsx from 'clsx';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useLogin } from '../../hooks/LoginService';
 import { ROUTES, RouteType } from '../../util/RoutingPath';
 import DrawerListItem from './components/DrawerListItem';
 import TutorialSubList from './components/TutorialSubList';
 import { Role } from 'shared/dist/model/Role';
+import { getVersionOfApp } from '../../hooks/fetching/Information';
 
 const DRAWER_WIDTH_OPEN = 240;
 const DRAWER_WIDTH_CLOSED = 56;
@@ -42,6 +51,13 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     toolbar: {
       ...theme.mixins.toolbar,
+    },
+    version: {
+      position: 'absolute',
+      bottom: theme.spacing(1),
+      left: theme.spacing(1),
+      right: theme.spacing(1),
+      textAlign: 'center',
     },
   })
 );
@@ -108,6 +124,7 @@ function Drawer({
 }: DrawerProps): JSX.Element {
   const classes = useStyles();
   const { userData } = useLogin();
+  const [version, setVersion] = useState<string | undefined>(undefined);
 
   if (!userData) {
     throw new Error('Drawer without a user should be rendered. This is forbidden.');
@@ -120,6 +137,12 @@ function Drawer({
     substituteRoutes,
     managementRoutes,
   } = useMemo(() => filterRoutes(userData.roles), [userData.roles]);
+
+  useEffect(() => {
+    getVersionOfApp()
+      .then(version => setVersion(version))
+      .catch(() => setVersion(undefined));
+  });
 
   return (
     <MuiDrawer
@@ -207,6 +230,22 @@ function Drawer({
           </>
         )}
       </List>
+
+      {version && (
+        <Typography className={classes.version} variant='caption'>
+          {open && <>Version: </>}
+
+          <Link
+            color='inherit'
+            href={`https://github.com/Dudrie/Tutor-Management-System/releases/tag/v${version}`}
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            {version}
+            <ExternalLinkIcon fontSize='inherit' />
+          </Link>
+        </Typography>
+      )}
     </MuiDrawer>
   );
 }

--- a/client/src/hooks/FetchingService.ts
+++ b/client/src/hooks/FetchingService.ts
@@ -6,6 +6,7 @@ import * as tutorialFunctions from './fetching/Tutorial';
 import * as userFunctions from './fetching/User';
 import * as scheinExamFunctions from './fetching/ScheinExam';
 import * as pdfFunctions from './fetching/Files';
+import * as informationFunctions from './fetching/Information';
 
 export function useAxios() {
   return {
@@ -17,5 +18,6 @@ export function useAxios() {
     ...scheincriteriaFunctions,
     ...scheinExamFunctions,
     ...pdfFunctions,
+    ...informationFunctions,
   };
 }

--- a/client/src/hooks/fetching/Information.ts
+++ b/client/src/hooks/fetching/Information.ts
@@ -1,0 +1,11 @@
+import axios from './Axios';
+
+export async function getVersionOfApp(): Promise<string> {
+  const response = await axios.get<string>(`information/version`);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return Promise.reject(`Wrong status code (${response.status}).`);
+}

--- a/client/src/view/AppBar.tsx
+++ b/client/src/view/AppBar.tsx
@@ -157,6 +157,7 @@ function AppBar(props: PropType): JSX.Element {
           className={classes.iconButton}
           href='https://github.com/Dudrie/Tutor-Management-System/issues'
           target='_blank'
+          rel='noopener noreferrer'
         >
           <GitHubIcon fontSize='default' />
         </IconButton>

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -115,11 +115,6 @@ function initEndpoints() {
   registerAPIEndpoint(`${BASE_API_PATH}/excel`, excelRouter);
   registerAPIEndpoint(`${BASE_API_PATH}/locales`, languageRouter);
 
-  // FIXME: REMOVE ME!
-  app.use(`${BASE_API_PATH}/superlongrequest`, (req, res) => {
-    setTimeout(() => res.status(204).send(), 1000);
-  });
-
   // If there's a request which starts with the BASE_API_PATH which did not get handled yet, throw a not found error.
   app.use(BASE_API_PATH, req => {
     throw new EndpointNotFoundError(`Endpoint ${req.url}@${req.method} was not found.`);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,6 +26,7 @@ import studentRouter from './services/student-service/StudentService.routes';
 import tutorialRouter from './services/tutorial-service/TutorialService.routes';
 import authenticationRouter from './services/user-service/authentication.routes';
 import userRouter from './services/user-service/UserService.routes';
+import informationRouter from './services/information-service/InformationServcive.routes';
 
 const BASE_API_PATH = '/api';
 const app = express();
@@ -113,6 +114,7 @@ function initEndpoints() {
   registerAPIEndpoint(`${BASE_API_PATH}/mail`, mailRouter);
   registerAPIEndpoint(`${BASE_API_PATH}/pdf`, pdfRouter);
   registerAPIEndpoint(`${BASE_API_PATH}/excel`, excelRouter);
+  registerAPIEndpoint(`${BASE_API_PATH}/information`, informationRouter);
   registerAPIEndpoint(`${BASE_API_PATH}/locales`, languageRouter);
 
   // If there's a request which starts with the BASE_API_PATH which did not get handled yet, throw a not found error.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,6 +5,7 @@ import initApp from './app';
 import { databaseConfig } from './helpers/config';
 import Logger from './helpers/Logger';
 import { StartUpError } from './model/Errors';
+import { initScheincriteriaBlueprints } from './model/scheincriteria/Scheincriteria';
 import userService from './services/user-service/UserService.class';
 
 /**
@@ -67,6 +68,8 @@ async function startServer() {
     Logger.info(`Starting server with version ${pkgInfo.version}...`);
 
     await connectToDB();
+
+    initScheincriteriaBlueprints();
 
     const app = initApp();
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,6 @@
 import { Server } from 'http';
 import mongoose from 'mongoose';
+import pkgInfo from '../package.json';
 import initApp from './app';
 import { databaseConfig } from './helpers/config';
 import Logger from './helpers/Logger';
@@ -63,13 +64,17 @@ async function initAdmin() {
  */
 async function startServer() {
   try {
+    Logger.info(`Starting server with version ${pkgInfo.version}...`);
+
     await connectToDB();
 
     const app = initApp();
 
     await initAdmin();
 
-    const server = app.listen(8080, () => Logger.info('Server started on port 8080.'));
+    const server = app.listen(8080, () =>
+      Logger.info(`Server (v${pkgInfo.version}) started on port 8080.`)
+    );
 
     // Mark every active request so the server can be gracefully stopped.
     server.on('request', (req, res) => {

--- a/server/src/services/information-service/InformationServcive.routes.ts
+++ b/server/src/services/information-service/InformationServcive.routes.ts
@@ -1,0 +1,12 @@
+import Router from 'express-promise-router';
+import informationService from './InformationService.class';
+
+const informationRouter = Router();
+
+informationRouter.get('/version', (_, res) => {
+  const version: string = informationService.getVersion();
+
+  res.send(version);
+});
+
+export default informationRouter;

--- a/server/src/services/information-service/InformationService.class.ts
+++ b/server/src/services/information-service/InformationService.class.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+import fs from 'fs';
+import Logger from '../../helpers/Logger';
+
+class InformationService {
+  public getVersion(): string {
+    try {
+      const pathToPackage = path.resolve(process.cwd(), '..', 'package.json');
+      const contents = fs.readFileSync(pathToPackage).toString();
+      const pkgInfo = JSON.parse(contents);
+
+      if (pkgInfo.version) {
+        return pkgInfo.version.toString();
+      } else {
+        Logger.error('package.json does not contain a version field.');
+        throw new Error("Package does not contain a 'version' field.");
+      }
+    } catch (err) {
+      throw { message: 'Could not retrieve version from file.' };
+    }
+  }
+}
+
+const informationService = new InformationService();
+
+export default informationService;

--- a/server/src/services/scheincriteria-service/ScheincriteriaService.routes.ts
+++ b/server/src/services/scheincriteria-service/ScheincriteriaService.routes.ts
@@ -7,14 +7,13 @@ import {
 } from 'shared/dist/model/ScheinCriteria';
 import { validateAgainstScheincriteriaDTO } from 'shared/dist/validators/Scheincriteria';
 import {
-  checkRoleAccess,
   checkAccess,
+  checkRoleAccess,
   hasUserOneOfRoles,
   isUserTutorOfTutorial,
 } from '../../middleware/AccessControl';
 import { validateRequestBody } from '../../middleware/Validation';
 import { ValidationError } from '../../model/Errors';
-import { initScheincriteriaBlueprints } from '../../model/scheincriteria/Scheincriteria';
 import scheincriteriaService from './ScheincriteriaService.class';
 
 function validateScheincriteriaDTOData(req: Request, res: Response, next: NextFunction) {
@@ -26,8 +25,6 @@ function validateScheincriteriaDTOData(req: Request, res: Response, next: NextFu
 
   next();
 }
-
-initScheincriteriaBlueprints();
 
 const scheincriteriaRouter = Router();
 


### PR DESCRIPTION
# :ticket: Description
Add a version indicator to both the server and the client.

Additionally this changes the order of operations on the server start: Now a connection to the DB is established before anything else. Afterwards the schein criteria blueprints get loaded before the rest of the startup routine is executed.
<!-- Describe this PR -->

# 🎯 ToDos
- [x] Server
- [x] Client

# :lock: Closes
- Closes #135 
<!-- Which issue(s) is (are) being closed by the PR? -->
