### PR TITLE
Fix changing tutorial of student not working.

### DIFF
--- a/server/src/services/student-service/StudentService.class.ts
+++ b/server/src/services/student-service/StudentService.class.ts
@@ -317,6 +317,8 @@ class StudentService {
       return;
     }
 
+    await teamService.removeStudentAsMemberFromTeam(student, { saveStudent: true });
+
     const oldTutorial = isDocument(student.tutorial)
       ? student.tutorial
       : await tutorialService.getDocumentWithID(student.tutorial.toString());
@@ -326,8 +328,6 @@ class StudentService {
     oldTutorial.students = oldTutorial.students.filter(
       stud => studentId !== getIdOfDocumentRef(stud)
     );
-
-    await teamService.removeStudentAsMemberFromTeam(student, { saveStudent: false });
 
     newTutorial.students.push(student);
     student.tutorial = newTutorial;


### PR DESCRIPTION
# :ticket: Description
Fixes an issue where a student could not be moved to a different tutorial due to the wrong (out-dated) document being used.
<!-- Describe this PR -->
