### PR TITLE
Add achieved points of subexercises to the generated PDFs.

### DIFF
--- a/server/src/services/pdf-service/PdfService.class.ts
+++ b/server/src/services/pdf-service/PdfService.class.ts
@@ -4,7 +4,11 @@ import JSZip from 'jszip';
 import MarkdownIt from 'markdown-it';
 import path from 'path';
 import puppeteer from 'puppeteer';
-import { PointMap, convertExercisePointInfoToString } from 'shared/dist/model/Points';
+import {
+  PointMap,
+  convertExercisePointInfoToString,
+  ExercisePointInfo,
+} from 'shared/dist/model/Points';
 import { ScheincriteriaSummaryByStudents } from 'shared/dist/model/ScheinCriteria';
 import { Student } from 'shared/dist/model/Student';
 import { User } from 'shared/dist/model/User';
@@ -163,7 +167,7 @@ class PdfService {
     const pointInfo: SheetPointInfo = { achieved: 0, total: { must: 0, bonus: 0 } };
     let exerciseMarkdown: string = '';
 
-    entries.forEach(({ exName, entry, exPoints }) => {
+    entries.forEach(({ exName, entry, exPoints, subexercises }) => {
       const achievedPts = PointMap.getPointsOfEntry(entry);
       const exMaxPoints: string = convertExercisePointInfoToString(exPoints);
 
@@ -171,7 +175,42 @@ class PdfService {
       pointInfo.total.must += exPoints.must;
       pointInfo.total.bonus += exPoints.bonus;
 
-      exerciseMarkdown += `## Aufgabe ${exName} [${achievedPts} / ${exMaxPoints}]  \n\n${entry.comment}\n\n`;
+      exerciseMarkdown += `## Aufgabe ${exName} [${achievedPts} / ${exMaxPoints}]\n\n`;
+
+      if (typeof entry.points === 'object' && subexercises.length > 0) {
+        const subExData: { name: string; achieved: number; total: ExercisePointInfo }[] = [];
+
+        for (const subEx of subexercises) {
+          const achievedPts = entry.points[subEx.id];
+          subExData.push({
+            name: subEx.exName,
+            achieved: achievedPts || 0,
+            total: subEx.exPoints,
+          });
+        }
+
+        let subexerciseMarkdown = '';
+
+        subExData.forEach(({ name }) => {
+          subexerciseMarkdown += `|${name}`;
+        });
+        subexerciseMarkdown += '|\n';
+
+        subExData.forEach(() => {
+          subexerciseMarkdown += '|:-----:';
+        });
+        subexerciseMarkdown += '|\n';
+
+        subExData.forEach(({ achieved, total }) => {
+          const totalString = convertExercisePointInfoToString(total);
+          subexerciseMarkdown += `|${achieved} / ${totalString}`;
+        });
+        subexerciseMarkdown += '|\n';
+
+        exerciseMarkdown += `${subexerciseMarkdown}\n\n`;
+      }
+
+      exerciseMarkdown += `${entry.comment}\n\n`;
     });
 
     const totalPointInfo = convertExercisePointInfoToString(pointInfo.total);

--- a/server/src/services/team-service/TeamService.class.ts
+++ b/server/src/services/team-service/TeamService.class.ts
@@ -21,11 +21,14 @@ import studentService from '../student-service/StudentService.class';
 import tutorialService from '../tutorial-service/TutorialService.class';
 import Logger from '../../helpers/Logger';
 
+type SubExPointInformation = Omit<PointInformation, 'entry'>;
+
 export interface PointInformation {
   id: string;
   exName: string;
   exPoints: ExercisePointInfo;
   entry: PointMapEntry;
+  subexercises: SubExPointInformation[];
 }
 
 class TeamService {
@@ -167,9 +170,25 @@ class TeamService {
 
     sheet.exercises.forEach(ex => {
       const entry = pointMap.getPointEntry(new PointId(sheetId, ex));
+      const subexercises: SubExPointInformation[] = [];
+
+      ex.subexercises.forEach(subex => {
+        subexercises.push({
+          id: subex.id,
+          exName: subex.exName,
+          exPoints: getPointsOfExercise(subex),
+          subexercises: [],
+        });
+      });
 
       if (entry) {
-        entries.push({ id: ex.id, exName: ex.exName, entry, exPoints: getPointsOfExercise(ex) });
+        entries.push({
+          id: ex.id,
+          exName: ex.exName,
+          entry,
+          exPoints: getPointsOfExercise(ex),
+          subexercises,
+        });
       }
     });
 


### PR DESCRIPTION
# :ticket: Description
This PR adds tables to the generated assessment PDFs to display the achieved points in the subexercises. The tables will only be visible if the exercise contains subexercises.
<!-- Describe this PR -->

# :lock: Closes
- Closes #182 
<!-- Which issue(s) is (are) being closed by the PR? -->
