### PR TITLE
Disable the "select all" behaviour on the markdown field if it gains focus.

### DIFF
--- a/client/src/components/forms/components/FormikMarkdownTextfield.tsx
+++ b/client/src/components/forms/components/FormikMarkdownTextfield.tsx
@@ -52,7 +52,7 @@ function FormikMarkdownTextfield({ name, ...other }: FormikTextFieldProps): JSX.
           <Markdown markdown={value} />
         </div>
       ) : (
-        <FormikTextField name={name} multiline {...other} />
+        <FormikTextField name={name} multiline disableSelectAllOnFocus {...other} />
       )}
     </div>
   );

--- a/client/src/components/forms/components/FormikTextField.tsx
+++ b/client/src/components/forms/components/FormikTextField.tsx
@@ -7,6 +7,7 @@ interface Props {
   name: string;
   FormikFieldProps?: Omit<FieldAttributes<any>, 'name'>;
   isPercentage?: boolean;
+  disableSelectAllOnFocus?: boolean;
 }
 
 type OutlineTextFieldClassKeys = 'root' | 'notchedOutline';
@@ -22,6 +23,7 @@ function FormikTextField({
   FormikFieldProps,
   helperText,
   InputProps,
+  disableSelectAllOnFocus,
   ...textfieldProps
 }: FormikTextFieldProps): JSX.Element {
   function getValue(fieldValue: any): any {
@@ -32,6 +34,12 @@ function FormikTextField({
     }
 
     return fieldValue;
+  }
+
+  function handleFocus(event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    if (!disableSelectAllOnFocus) {
+      event.target.select();
+    }
   }
 
   return (
@@ -56,7 +64,7 @@ function FormikTextField({
           }}
           helperText={(!!touched && error) || helperText}
           error={touched && !!error}
-          onFocus={e => e.target.select()}
+          onFocus={handleFocus}
         >
           {children}
         </TextField>


### PR DESCRIPTION
# :ticket: Description
If the FormikMarkdownTextField gains focus it does NOT select all it's text anymore. This makes it easier to fix typos in the assessment comments.

This changes FormikTextField aswell to support disabling the behaviour which selects all text in the TextField if it gets the focus.
<!-- Describe this PR -->

# :lock: Closes
- Clsoes #186 
<!-- Which issue(s) is (are) being closed by the PR? -->
