### PR TITLE
Fix config folder being copied to the wrong folder.

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc -b",
-    "postbuild": "copyfiles -E \"config/**/*\" build/",
+    "postbuild": "copyfiles -E \"config/**/*\" build/src/",
     "build:watch": "tsc -b -w",
     "start": "ts-node-dev --no-notify . --no-lazy",
     "test": "jest --detectOpenHandles --runInBand",


### PR DESCRIPTION
# :ticket: Description
After updating to TypeScript 3.7 the output structure of the server build changed and does not contain the config folder anymore. This is fixed with this PR.
<!-- Describe this PR -->

<!-- # :lock: Closes -->
<!-- Which issue(s) is (are) being closed by the PR? -->
