### PR TITLE
Change the position of the backup download button

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,10 +23,10 @@
   ],
   "dependencies": {
     "@date-io/date-fns": "^1.3.11",
-    "@material-ui/core": "^4.5.1",
+    "@material-ui/core": "^4.8.0",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/pickers": "^3.2.7",
-    "@material-ui/styles": "^4.5.0",
+    "@material-ui/styles": "^4.7.1",
     "axios": "^0.19.0",
     "clsx": "^1.0.4",
     "downshift": "^3.3.5",

--- a/client/src/view/dashboard/Dashboard.tsx
+++ b/client/src/view/dashboard/Dashboard.tsx
@@ -13,8 +13,6 @@ import {
 import AdminStatsCard from './components/AdminStatsCard';
 import AllTutorialStatistics from './components/AllTutorialStatistics';
 import TutorialStatistics from './components/TutorialStatistics';
-import { useSnackbar } from 'notistack';
-import { saveBlob } from '../../util/helperFunctions';
 
 export interface TutorialSummaryInfo {
   tutorial: Tutorial;
@@ -27,11 +25,9 @@ function isAdmin(userData: LoggedInUser | undefined): boolean {
 
 function Dashboard(): JSX.Element {
   const { userData } = useLogin();
-  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const {
     getScheinCriteriaSummariesOfAllStudentsOfTutorial,
     getScheinCriteriaSummaryOfAllStudentsWithTutorialSlots,
-    getTutorialXLSX,
   } = useAxios();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -40,8 +36,6 @@ function Dashboard(): JSX.Element {
   >([]);
 
   const [summaries, setSummaries] = useState<StudentByTutorialSlotSummaryMap>({});
-
-  useEffect(() => {}, [getScheinCriteriaSummaryOfAllStudentsWithTutorialSlots]);
 
   useEffect(() => {
     setIsLoading(true);
@@ -79,20 +73,6 @@ function Dashboard(): JSX.Element {
     userData,
   ]);
 
-  async function handleDownloadXLSX(tutorial: Tutorial) {
-    const snackId = enqueueSnackbar('Erstelle XLSX...', { variant: 'info', persist: true });
-
-    try {
-      const blob = await getTutorialXLSX(tutorial.id);
-
-      saveBlob(blob, `Tutorium_${tutorial.slot}.xlsx`);
-    } catch {
-      enqueueSnackbar('XLSX konnte nicht erstellt werden.', { variant: 'error' });
-    } finally {
-      closeSnackbar(snackId || undefined);
-    }
-  }
-
   return (
     <div>
       {isLoading ? (
@@ -107,9 +87,7 @@ function Dashboard(): JSX.Element {
 
           <AllTutorialStatistics
             items={tutorialsWithScheinCriteriaSummaries}
-            createRowFromItem={item => (
-              <TutorialStatistics value={item} onDownloadClicked={handleDownloadXLSX} />
-            )}
+            createRowFromItem={item => <TutorialStatistics value={item} />}
             placeholder='Keine Tutorien vorhanden'
           />
         </>

--- a/client/src/view/dashboard/components/TutorialStatistics.tsx
+++ b/client/src/view/dashboard/components/TutorialStatistics.tsx
@@ -1,12 +1,10 @@
-import { createStyles, makeStyles, Paper, Theme, Typography, IconButton } from '@material-ui/core';
+import { createStyles, makeStyles, Paper, Theme, Typography } from '@material-ui/core';
 import React from 'react';
+import { getDisplayStringForTutorial } from '../../../util/helperFunctions';
 import { TutorialSummaryInfo } from '../Dashboard';
 import ScheinCriteriaStatsCard from './ScheinCrtieriaStatsCard';
 import ScheinPassedStatsCard from './ScheinPassedStatsCard';
 import TutorialStatsCard from './TutorialStatsCard';
-import { getDisplayStringForTutorial } from '../../../util/helperFunctions';
-import { Download as DownloadIcon } from 'mdi-material-ui';
-import { Tutorial } from 'shared/dist/model/Tutorial';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -31,10 +29,9 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface TutorialStatisticsProps {
   value: TutorialSummaryInfo;
-  onDownloadClicked: (tutorial: Tutorial) => void;
 }
 
-function TutorialStatistics({ value, onDownloadClicked }: TutorialStatisticsProps): JSX.Element {
+function TutorialStatistics({ value }: TutorialStatisticsProps): JSX.Element {
   const classes = useStyles();
   const activeCriteria: string[] = [];
 
@@ -50,14 +47,6 @@ function TutorialStatistics({ value, onDownloadClicked }: TutorialStatisticsProp
     <>
       <Paper className={classes.tutorialHeading}>
         <Typography variant='h5'>{getDisplayStringForTutorial(value.tutorial)}</Typography>
-
-        <IconButton
-          size='small'
-          className={classes.iconButton}
-          onClick={() => onDownloadClicked(value.tutorial)}
-        >
-          <DownloadIcon />
-        </IconButton>
       </Paper>
       <div className={classes.cardsContainer}>
         <TutorialStatsCard value={value} />

--- a/server/src/services/excel-service/ExcelService.routes.ts
+++ b/server/src/services/excel-service/ExcelService.routes.ts
@@ -4,6 +4,7 @@ import {
   checkAccess,
   hasUserOneOfRoles,
   isUserTutorOfTutorial,
+  isUserCorrectorOfTutorial,
 } from '../../middleware/AccessControl';
 import excelService from './ExcelService.class';
 
@@ -11,7 +12,7 @@ const excelRouter = Router();
 
 excelRouter.get(
   '/tutorial/:id',
-  ...checkAccess(hasUserOneOfRoles(Role.ADMIN), isUserTutorOfTutorial),
+  ...checkAccess(hasUserOneOfRoles(Role.ADMIN), isUserTutorOfTutorial, isUserCorrectorOfTutorial),
   async (req, res) => {
     const tutorialId = req.params.id;
     const excelBuffer = await excelService.generateXLSXForTutorial(tutorialId);


### PR DESCRIPTION
# :ticket: Description
This moves the download buttons for the tutorial backups to the AppBar and removes them from the Dashboard. This way an ever-loading dashboard does not prevent the user from downloading the backup.

Furthermore this PR allows correctors to download the backups aswell.
<!-- Describe this PR -->

# :lock: Closes
- Closes #193 
<!-- Which issue(s) is (are) being closed by the PR? -->
