### PR TITLE
Fix dates of tutorials not getting sorted.

### DIFF
--- a/server/src/services/tutorial-service/TutorialService.class.ts
+++ b/server/src/services/tutorial-service/TutorialService.class.ts
@@ -269,7 +269,7 @@ class TutorialService {
       id,
       slot,
       tutor: tutor ? getIdOfDocumentRef(tutor) : undefined,
-      dates: dates.map(d => d.toISOString()),
+      dates: dates.sort((a, b) => a.getTime() - b.getTime()).map(d => d.toISOString()),
       correctors: correctors.map(getIdOfDocumentRef),
       startTime,
       endTime,


### PR DESCRIPTION
# :ticket: Description
This adds sorting of dates before the tutorial gets send as a response by the API.
<!-- Describe this PR -->

# :lock: Closes
- Closes #218 
<!-- Which issue(s) is (are) being closed by the PR? -->
