### PR TITLE
Calculation of all schein statuses of all students lead to slow tms afterwards

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,8 +1,8 @@
-# 🗄 Server
-<!-- Changes to the server -->
-
 # 💻 Client
 <!-- Changes to the client -->
+
+# 🗄 Server
+<!-- Changes to the server -->
 
 # 📣 General
 <!-- General changes which might affect both, client & server -->

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "downshift": "^3.4.8",
     "fast-csv": "^3.4.0",
     "file-saver": "^2.0.2",
-    "formik": "^2.0.8",
+    "formik": "^2.1.3",
     "generate-password": "^1.4.2",
     "github-markdown-css": "^3.0.1",
     "html-react-parser": "^0.10.0",

--- a/client/src/components/forms/UserForm.tsx
+++ b/client/src/components/forms/UserForm.tsx
@@ -132,6 +132,7 @@ function UserForm({
       initialValues={initialFormState}
       validationSchema={ValidationSchema}
       onSubmit={onSubmit}
+      enableDebug
       enableErrorsInDebug
     >
       {({ setFieldValue, values }) => (

--- a/client/src/view/studentmanagement/AllStudentsAdminView.tsx
+++ b/client/src/view/studentmanagement/AllStudentsAdminView.tsx
@@ -73,8 +73,16 @@ function AdminStudentManagement(): JSX.Element {
   async function generateCSVFile() {
     setCreatingCSVFile(true);
 
-    const summaries = await getScheinCriteriaSummaryOfAllStudents();
+    // const summaries = await getScheinCriteriaSummaryOfAllStudents();
+    // const exams = await getAllScheinExams();
+    // const sheets = await getAllSheets();
+
     const dataArray: Row[] = [];
+    const [summaries, sheets, exams] = await Promise.all([
+      getScheinCriteriaSummaryOfAllStudents(),
+      getAllSheets(),
+      getAllScheinExams(),
+    ]);
 
     for (const {
       id,
@@ -87,8 +95,6 @@ function AdminStudentManagement(): JSX.Element {
       points,
     } of students) {
       const criteriaResult = summaries[id];
-      const exams = await getAllScheinExams();
-      const sheets = await getAllSheets();
       const pointsOfStudent = new PointMap(points);
 
       const data: RowMap = {

--- a/dev-tools/src/fetch/helpers.ts
+++ b/dev-tools/src/fetch/helpers.ts
@@ -1,0 +1,40 @@
+import { AxiosInstance } from 'axios';
+import { AttendanceDTO, Attendance } from 'shared/src/model/Attendance';
+import { UpdatePointsDTO } from 'shared/src/model/Points';
+import { SheetDTO, Sheet } from 'shared/src/model/Sheet';
+
+export async function createSheet(sheetInfo: SheetDTO, axios: AxiosInstance): Promise<Sheet> {
+  const response = await axios.post<Sheet>('sheet', sheetInfo);
+
+  if (response.status === 201) {
+    return response.data;
+  }
+
+  return Promise.reject(`Wrong status code (${response.status}).`);
+}
+
+export async function setAttendanceOfStudent(
+  id: string,
+  attendanceInfo: AttendanceDTO,
+  axios: AxiosInstance
+): Promise<Attendance> {
+  const response = await axios.put<Attendance>(`student/${id}/attendance`, attendanceInfo);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return Promise.reject(`Wrong status code (${response.status}).`);
+}
+
+export async function setPointsOfStudent(
+  studentId: string,
+  points: UpdatePointsDTO,
+  axios: AxiosInstance
+): Promise<void> {
+  const response = await axios.put(`student/${studentId}/point`, points);
+
+  if (response.status !== 204) {
+    return Promise.reject(`Wrong status code (${response.status}).`);
+  }
+}

--- a/dev-tools/src/generateStudents.ts
+++ b/dev-tools/src/generateStudents.ts
@@ -2,6 +2,9 @@ import Axios from 'axios';
 import { LoggedInUser } from 'shared/src/model/User';
 import { StudentDTO, StudentStatus, Student } from 'shared/src/model/Student';
 import { TutorialDTO, Tutorial } from 'shared/src/model/Tutorial';
+import { Sheet, SheetDTO, ExerciseDTO } from 'shared/src/model/Sheet';
+import { createSheet, setPointsOfStudent } from './fetch/helpers';
+import { PointMap, PointId, PointsOfSubexercises } from 'shared/src/model/Points';
 
 function createBaseURL(): string {
   return 'http://localhost:8080/api';
@@ -24,6 +27,10 @@ const axios = Axios.create({
 
 const cookies: string[] = [];
 
+function roundNumber(number: number, places: number = 2): number {
+  return Math.round(number * Math.pow(10, places)) / Math.pow(10, places);
+}
+
 async function login(username: string, password: string): Promise<void> {
   // We build the Authorization header by ourselfs because the axios library does NOT use UTF-8 to encode the string as base64.
   const encodedAuth = Buffer.from(username + ':' + password, 'utf8').toString('base64');
@@ -44,37 +51,114 @@ async function login(username: string, password: string): Promise<void> {
   }
 }
 
+async function createTutorial(): Promise<Tutorial> {
+  const tutorialDTO: TutorialDTO = {
+    slot: 'G1',
+    startTime: '09:45:00',
+    endTime: '11:15:00',
+    dates: [new Date().toDateString(), new Date().toDateString()],
+    correctorIds: [],
+  };
+
+  const tutorialResponse = await axios.post<Tutorial>('/tutorial', tutorialDTO);
+  if (tutorialResponse.status !== 201) {
+    throw new Error('Tutorial could not be created.');
+  }
+
+  return tutorialResponse.data;
+}
+
+async function createSheets(): Promise<Sheet[]> {
+  const sheets: Sheet[] = [];
+
+  for (let i = 0; i < 12; i++) {
+    const sheetNo = i + 1;
+    const hasSubexercises = Math.random() >= 0.5;
+    const subexercises: ExerciseDTO[] = [];
+
+    if (hasSubexercises) {
+      for (let i = 0; i < Math.round(Math.random() * 2 + 1); i++) {
+        subexercises.push({
+          exName: `Subex ${i + 1}`,
+          maxPoints: roundNumber(Math.random() * 12 + 4),
+          subexercises: [],
+          bonus: false,
+        });
+      }
+    }
+
+    const maxPoints =
+      subexercises.length > 0
+        ? subexercises.reduce((sum, ex) => ex.maxPoints + sum, 0)
+        : roundNumber(Math.random() * 10 + 5, 0);
+
+    const sheetDTO: SheetDTO = {
+      sheetNo,
+      exercises: [
+        {
+          exName: `Exercise ${sheetNo}`,
+          maxPoints,
+          subexercises,
+          bonus: false,
+        },
+      ],
+      bonusSheet: false,
+    };
+
+    const sheet = await createSheet(sheetDTO, axios);
+    sheets.push(sheet);
+
+    console.log(`Created sheet #${sheet.sheetNo}`);
+  }
+
+  console.log('All sheets created.');
+
+  return sheets;
+}
+
 async function run() {
   try {
     await login('admin', 'admin');
 
-    const tutorialDTO: TutorialDTO = {
-      slot: 'G1',
-      startTime: '09:45:00',
-      endTime: '11:15:00',
-      dates: [new Date().toDateString(), new Date().toDateString()],
-      correctorIds: [],
-    };
-
-    const tutorialResponse = await axios.post<Tutorial>('/tutorial', tutorialDTO);
-
-    if (tutorialResponse.status !== 201) {
-      throw new Error('Tutorial could not be created.');
-    }
+    const tutorial = await createTutorial();
+    const sheets = await createSheets();
 
     for (let i = 0; i < 600; i++) {
       const studentDTO: StudentDTO = {
         firstname: 'Test',
-        lastname: `Student #${i.toString().padStart(2, '0')}`,
+        lastname: `Student #${i.toString().padStart(3, '0')}`,
         status: StudentStatus.ACTIVE,
-        tutorial: tutorialResponse.data.id,
+        tutorial: tutorial.id,
+        matriculationNo: i.toString().padStart(7, '0'),
         // TODO: Rest of properties?
       };
 
-      await axios.post<Student>('/student', studentDTO);
+      const student = (await axios.post<Student>('/student', studentDTO)).data;
+      const pointMap = new PointMap();
+
+      for (const sheet of sheets) {
+        for (const exercise of sheet.exercises) {
+          if (exercise.subexercises.length > 0) {
+            const entry: PointsOfSubexercises = {};
+
+            exercise.subexercises.forEach(subEx => {
+              entry[subEx.id] = roundNumber(Math.random() * subEx.maxPoints);
+            });
+
+            pointMap.setPointEntry(new PointId(sheet.id, exercise), { comment: '', points: entry });
+          } else {
+            pointMap.setPointEntry(new PointId(sheet.id, exercise), {
+              comment: '',
+              points: roundNumber(Math.random() * exercise.maxPoints),
+            });
+          }
+        }
+      }
+
+      await setPointsOfStudent(student.id, { points: pointMap.toDTO() }, axios);
 
       if (i % 50 === 0) {
-        console.log(`Generated students #${i}`);
+        console.log(`Created student #${i}`);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.3",
   "workspaces": [
     "client",
     "server",

--- a/server/src/model/documents/StudentDocument.ts
+++ b/server/src/model/documents/StudentDocument.ts
@@ -79,6 +79,16 @@ export class StudentSchema extends Typegoose
   @prop({ default: 0 })
   cakeCount!: number;
 
+  private _teamDocument?: TeamDocument | undefined = undefined;
+
+  get teamDocument(): TeamDocument | undefined {
+    return this._teamDocument;
+  }
+
+  set teamDocument(document: TeamDocument | undefined) {
+    this._teamDocument = document;
+  }
+
   @instanceMethod
   async getTeam(this: InstanceType<StudentSchema>): Promise<TeamDocument | undefined> {
     if (!this.team) {

--- a/server/src/model/documents/StudentDocument.ts
+++ b/server/src/model/documents/StudentDocument.ts
@@ -6,6 +6,7 @@ import {
   prop,
   Ref,
   Typegoose,
+  isDocument,
 } from '@typegoose/typegoose';
 import { Document, Model, Types } from 'mongoose';
 import { fieldEncryption } from 'mongoose-field-encryption';
@@ -82,6 +83,10 @@ export class StudentSchema extends Typegoose
   async getTeam(this: InstanceType<StudentSchema>): Promise<TeamDocument | undefined> {
     if (!this.team) {
       return undefined;
+    }
+
+    if (isDocument(this.team)) {
+      return this.team;
     }
 
     try {

--- a/server/src/model/documents/TeamDocument.ts
+++ b/server/src/model/documents/TeamDocument.ts
@@ -1,5 +1,5 @@
 import { arrayProp, prop, Ref, Typegoose } from '@typegoose/typegoose';
-import { Document, Model } from 'mongoose';
+import { Document } from 'mongoose';
 import { PointMapDTO } from 'shared/dist/model/Points';
 import { Team } from 'shared/dist/model/Team';
 import { StudentDocument } from './StudentDocument';

--- a/server/src/model/documents/TeamDocument.ts
+++ b/server/src/model/documents/TeamDocument.ts
@@ -21,8 +21,3 @@ export class TeamSchema extends Typegoose
 }
 
 export interface TeamDocument extends TeamSchema, Document {}
-
-// Register the teamschema to be able to populate the corresponding fields in the other documents.
-new TeamSchema().getModelForClass(TeamSchema, {
-  schemaOptions: { collection: 'teams' },
-});

--- a/server/src/model/documents/TeamDocument.ts
+++ b/server/src/model/documents/TeamDocument.ts
@@ -1,5 +1,5 @@
 import { arrayProp, prop, Ref, Typegoose } from '@typegoose/typegoose';
-import { Document } from 'mongoose';
+import { Document, Model } from 'mongoose';
 import { PointMapDTO } from 'shared/dist/model/Points';
 import { Team } from 'shared/dist/model/Team';
 import { StudentDocument } from './StudentDocument';
@@ -21,3 +21,8 @@ export class TeamSchema extends Typegoose
 }
 
 export interface TeamDocument extends TeamSchema, Document {}
+
+// Register the teamschema to be able to populate the corresponding fields in the other documents.
+new TeamSchema().getModelForClass(TeamSchema, {
+  schemaOptions: { collection: 'teams' },
+});

--- a/server/src/model/scheincriteria/Scheincriteria.ts
+++ b/server/src/model/scheincriteria/Scheincriteria.ts
@@ -3,6 +3,14 @@ import { CriteriaInformation, ScheinCriteriaStatus } from 'shared/dist/model/Sch
 import * as Yup from 'yup';
 import Logger from '../../helpers/Logger';
 import { StudentDocument } from '../documents/StudentDocument';
+import { SheetDocument } from '../documents/SheetDocument';
+import { ScheinexamDocument } from '../documents/ScheinexamDocument';
+
+export interface CriteriaPayload {
+  student: StudentDocument;
+  sheets: SheetDocument[];
+  exams: ScheinexamDocument[];
+}
 
 export type StatusCheckResponse = Omit<ScheinCriteriaStatus, 'id' | 'name'>;
 export type CriteriaInformationWithoutName = Omit<CriteriaInformation, 'name' | 'studentSummaries'>;
@@ -14,7 +22,7 @@ export abstract class Scheincriteria {
     this.identifier = identifier;
   }
 
-  abstract async checkCriteriaStatus(student: StudentDocument): Promise<StatusCheckResponse>;
+  abstract checkCriteriaStatus(payload: CriteriaPayload): StatusCheckResponse;
 
   abstract async getInformation(
     students: StudentDocument[]

--- a/server/src/model/scheincriteria/criterias/AttendanceCriteria.ts
+++ b/server/src/model/scheincriteria/criterias/AttendanceCriteria.ts
@@ -1,27 +1,32 @@
 import { AttendanceState } from 'shared/dist/model/Attendance';
 import { ScheinCriteriaUnit } from 'shared/dist/model/ScheinCriteria';
 import scheincriteriaService from '../../../services/scheincriteria-service/ScheincriteriaService.class';
-import tutorialService from '../../../services/tutorial-service/TutorialService.class';
 import { StudentDocument } from '../../documents/StudentDocument';
-import { CriteriaInformationWithoutName, StatusCheckResponse } from '../Scheincriteria';
+import {
+  CriteriaInformationWithoutName,
+  CriteriaPayload,
+  StatusCheckResponse,
+} from '../Scheincriteria';
 import {
   PossiblePercentageCriteria,
   possiblePercentageCriteriaSchema,
 } from './PossiblePercentageCriteria';
-import { getIdOfDocumentRef } from '../../../helpers/documentHelpers';
 
 export class AttendanceCriteria extends PossiblePercentageCriteria {
   constructor(percentage: boolean, valueNeeded: number) {
     super('attendance', percentage, valueNeeded);
   }
 
-  async checkCriteriaStatus(student: StudentDocument): Promise<StatusCheckResponse> {
-    const tutorial = await tutorialService.getDocumentWithID(getIdOfDocumentRef(student.tutorial));
-    const total = tutorial.dates.length;
+  checkCriteriaStatus({ student }: CriteriaPayload): StatusCheckResponse {
+    // const tutorial = await tutorialService.getDocumentWithID(getIdOfDocumentRef(student.tutorial));
+    // const total = tutorial.dates.length;
 
+    let total = 0;
     let visitedOrExcused = 0;
 
     student.attendance.forEach(({ state }) => {
+      total += 1;
+
       if (state === AttendanceState.PRESENT || state === AttendanceState.EXCUSED) {
         visitedOrExcused += 1;
       }

--- a/server/src/model/scheincriteria/criterias/PresentationCriteria.ts
+++ b/server/src/model/scheincriteria/criterias/PresentationCriteria.ts
@@ -5,6 +5,7 @@ import scheincriteriaService from '../../../services/scheincriteria-service/Sche
 import { StudentDocument } from '../../documents/StudentDocument';
 import {
   CriteriaInformationWithoutName,
+  CriteriaPayload,
   Scheincriteria,
   StatusCheckResponse,
 } from '../Scheincriteria';
@@ -19,7 +20,7 @@ export class PresentationCriteria extends Scheincriteria {
     this.presentationsNeeded = presentationsNeeded;
   }
 
-  async checkCriteriaStatus(student: StudentDocument): Promise<StatusCheckResponse> {
+  checkCriteriaStatus({ student }: CriteriaPayload): StatusCheckResponse {
     const achieved = Object.values(student.presentationPoints).reduce(
       (prev, current) => prev + current,
       0

--- a/server/src/model/scheincriteria/criterias/ScheinexamCriteria.ts
+++ b/server/src/model/scheincriteria/criterias/ScheinexamCriteria.ts
@@ -16,6 +16,7 @@ import {
   CriteriaInformationWithoutName,
   Scheincriteria,
   StatusCheckResponse,
+  CriteriaPayload,
 } from '../Scheincriteria';
 import { ScheincriteriaPercentage } from '../ScheincriteriaDecorators';
 
@@ -32,8 +33,7 @@ export class ScheinexamCriteria extends Scheincriteria {
     this.percentageOfAllPointsNeeded = percentageOfAllPointsNeeded;
   }
 
-  async checkCriteriaStatus(student: StudentDocument): Promise<StatusCheckResponse> {
-    const exams = await scheinexamService.getAllScheinExamAsDocuments();
+  checkCriteriaStatus({ student, exams }: CriteriaPayload): StatusCheckResponse {
     const infos: StatusCheckResponse['infos'] = {};
     const { examsPassed, pointsAchieved, pointsTotal } = this.checkAllExams(exams, student, infos);
 

--- a/server/src/model/scheincriteria/criterias/SheetIndividualCriteria.ts
+++ b/server/src/model/scheincriteria/criterias/SheetIndividualCriteria.ts
@@ -5,7 +5,11 @@ import { CleanCriteriaShape } from '../../../helpers/typings';
 import scheincriteriaService from '../../../services/scheincriteria-service/ScheincriteriaService.class';
 import sheetService from '../../../services/sheet-service/SheetService.class';
 import { StudentDocument } from '../../documents/StudentDocument';
-import { CriteriaInformationWithoutName, StatusCheckResponse } from '../Scheincriteria';
+import {
+  CriteriaInformationWithoutName,
+  CriteriaPayload,
+  StatusCheckResponse,
+} from '../Scheincriteria';
 import { ScheincriteriaPossiblePercentage } from '../ScheincriteriaDecorators';
 import {
   PossiblePercentageCriteria,
@@ -29,11 +33,10 @@ export class SheetIndividualCriteria extends PossiblePercentageCriteria {
     this.percentagePerSheet = percentagePerSheet;
   }
 
-  async checkCriteriaStatus(student: StudentDocument): Promise<StatusCheckResponse> {
-    const sheets = await sheetService.getAllSheets();
+  checkCriteriaStatus({ student, sheets }: CriteriaPayload): StatusCheckResponse {
     const infos: StatusCheckResponse['infos'] = {};
     const totalSheetCount = sheets.reduce((count, sheet) => count + (sheet.bonusSheet ? 0 : 1), 0);
-    const sheetsPassed = await this.checkAllSheets(sheets, student, infos);
+    const sheetsPassed = this.checkAllSheets(sheets, student, infos);
 
     let passed: boolean = false;
 
@@ -57,14 +60,14 @@ export class SheetIndividualCriteria extends PossiblePercentageCriteria {
     throw new Error('Method not implemented.');
   }
 
-  private async checkAllSheets(
+  private checkAllSheets(
     sheets: Sheet[],
     student: StudentDocument,
     infos: StatusCheckResponse['infos']
   ) {
     let sheetsPassed = 0;
     for (const sheet of sheets) {
-      const achieved = await sheetService.getPointsOfStudent(student, sheet);
+      const achieved = sheetService.getPointsOfStudent(student, sheet);
       const total = sheetService.getSheetTotalPoints(sheet);
 
       let state = PassedState.NOTPASSED;

--- a/server/src/model/scheincriteria/criterias/SheetTotalCriteria.ts
+++ b/server/src/model/scheincriteria/criterias/SheetTotalCriteria.ts
@@ -3,7 +3,11 @@ import { Sheet } from 'shared/dist/model/Sheet';
 import scheincriteriaService from '../../../services/scheincriteria-service/ScheincriteriaService.class';
 import sheetService from '../../../services/sheet-service/SheetService.class';
 import { StudentDocument } from '../../documents/StudentDocument';
-import { CriteriaInformationWithoutName, StatusCheckResponse } from '../Scheincriteria';
+import {
+  CriteriaInformationWithoutName,
+  CriteriaPayload,
+  StatusCheckResponse,
+} from '../Scheincriteria';
 import {
   PossiblePercentageCriteria,
   possiblePercentageCriteriaSchema,
@@ -14,11 +18,9 @@ export class SheetTotalCriteria extends PossiblePercentageCriteria {
     super('sheetTotal', percentage, valueNeeded);
   }
 
-  async checkCriteriaStatus(student: StudentDocument): Promise<StatusCheckResponse> {
-    const sheets = await sheetService.getAllSheets();
+  checkCriteriaStatus({ student, sheets }: CriteriaPayload): StatusCheckResponse {
     const infos: StatusCheckResponse['infos'] = {};
-
-    const { pointsAchieved, pointsTotal } = await this.checkAllSheets(sheets, student, infos);
+    const { pointsAchieved, pointsTotal } = this.checkAllSheets(sheets, student, infos);
 
     let passed: boolean = false;
 
@@ -42,7 +44,7 @@ export class SheetTotalCriteria extends PossiblePercentageCriteria {
     throw new Error('Method not implemented.');
   }
 
-  private async checkAllSheets(
+  private checkAllSheets(
     sheets: Sheet[],
     student: StudentDocument,
     infos: StatusCheckResponse['infos']
@@ -51,7 +53,7 @@ export class SheetTotalCriteria extends PossiblePercentageCriteria {
     let pointsTotal = 0;
 
     for (const sheet of sheets) {
-      const achieved = await sheetService.getPointsOfStudent(student, sheet);
+      const achieved = sheetService.getPointsOfStudent(student, sheet);
       const total = sheetService.getSheetTotalPoints(sheet);
       pointsAchieved += achieved;
 

--- a/server/src/services/pdf-service/modules/PDFModule.ts
+++ b/server/src/services/pdf-service/modules/PDFModule.ts
@@ -5,6 +5,9 @@ import githubMarkdownCSS from '../css/githubMarkdown';
 import Logger from '../../../helpers/Logger';
 import puppeteer from 'puppeteer';
 
+/**
+ * @param T Type of the options passed to `generatePDF`.
+ */
 export abstract class PDFModule<T> {
   private readonly filename: string;
 

--- a/server/src/services/pdf-service/modules/PDFWithStudentsModule.ts
+++ b/server/src/services/pdf-service/modules/PDFWithStudentsModule.ts
@@ -1,13 +1,14 @@
-import { PDFModule } from './PDFModule';
 import { StudentDocument } from '../../../model/documents/StudentDocument';
+import { PDFModule } from './PDFModule';
 
-interface ShortenedMatriculationNumbers {
-  [studentId: string]: string;
+interface ShortendMatriculationInfo {
+  studentId: string;
+  shortenedNo: string;
 }
 
 export abstract class PDFWithStudentsModule<T> extends PDFModule<T> {
   /**
-   * Returns the shortened number for all students as a "Map" in the form `studentId` -> `short matriculation no.`.
+   * Returns the shortened number for all students together with the ID of the student to which the shortened matriculation number belongs to.
    *
    * Those shortened numbers are still enough to identify a student. However, this is only true if one only consideres the given students. If one extends that array without re-running this function the identifying feature may get lost.
    *
@@ -17,23 +18,72 @@ export abstract class PDFWithStudentsModule<T> extends PDFModule<T> {
    */
   protected getShortenedMatriculationNumbers(
     students: StudentDocument[]
-  ): ShortenedMatriculationNumbers {
-    const result: ShortenedMatriculationNumbers = {};
+  ): ShortendMatriculationInfo[] {
+    const result: ShortendMatriculationInfo[] = [];
+    const matriculationNos: { id: string; reversedNumber: string }[] = [];
 
     for (const student of students) {
-      result[student.id] = this.shortOneMatriculationNumber(student, students);
+      if (student.matriculationNo) {
+        matriculationNos.push({
+          id: student.id,
+          reversedNumber: this.reverseString(student.matriculationNo),
+        });
+      }
     }
 
-    return result;
-  }
+    matriculationNos.sort((a, b) => a.reversedNumber.localeCompare(b.reversedNumber));
 
-  protected sortShortenedMatriculationNumbers(
-    numbers: ShortenedMatriculationNumbers
-  ): [string, string][] {
-    return Object.entries(numbers).sort(([, matrA], [, matrB]) => matrA.localeCompare(matrB));
+    matriculationNos.forEach((current, idx) => {
+      let position: number;
+
+      if (idx === matriculationNos.length) {
+        const prev = matriculationNos[idx - 1];
+        position = this.getFirstDifferentPosition(current.reversedNumber, prev.reversedNumber);
+      } else {
+        const next = matriculationNos[idx + 1];
+        position = this.getFirstDifferentPosition(current.reversedNumber, next.reversedNumber);
+      }
+
+      const substring = this.reverseString(current.reversedNumber.substr(0, position + 1));
+      result.push({
+        studentId: current.id,
+        shortenedNo: substring.padStart(7, '*'),
+      });
+    });
+
+    return result.sort((a, b) => a.shortenedNo.localeCompare(b.shortenedNo));
   }
 
   /**
+   * Searches for the position of the first character which both strings __DO NOT__ have in common. This position is then returned.
+   *
+   * @param first First string
+   * @param second Second string
+   * @returns The first position in which both string differ. If they are completly equal the length of the first string is returned.
+   */
+  private getFirstDifferentPosition(first: string, second: string): number {
+    for (let i = 0; i < first.length; i++) {
+      if (first.charAt(i) !== second.charAt(i)) {
+        return i;
+      }
+    }
+
+    return first.length;
+  }
+
+  /**
+   * @param string String to reverse
+   * @returns The reversed string.
+   */
+  private reverseString(string: string): string {
+    return string
+      .split('')
+      .reverse()
+      .join('');
+  }
+
+  /**
+   * @deprecated // TODO: REMOVE ME
    * Generates a matriculation number with the form "***123" where the first digits get replaced with "*". All students in the `students` array get a unique matriculation number. Therefore these "shortened" numbers are still enough to identify a student.
    *
    * @param student Student to generate the short matriculation number for.

--- a/server/src/services/pdf-service/modules/PDFWithStudentsModule.ts
+++ b/server/src/services/pdf-service/modules/PDFWithStudentsModule.ts
@@ -34,17 +34,22 @@ export abstract class PDFWithStudentsModule<T> extends PDFModule<T> {
     matriculationNos.sort((a, b) => a.reversedNumber.localeCompare(b.reversedNumber));
 
     matriculationNos.forEach((current, idx) => {
-      let position: number;
+      let positionPrev: number = 0;
+      let positionNext: number = 0;
 
-      if (idx === matriculationNos.length) {
+      if (idx !== 0) {
         const prev = matriculationNos[idx - 1];
-        position = this.getFirstDifferentPosition(current.reversedNumber, prev.reversedNumber);
-      } else {
-        const next = matriculationNos[idx + 1];
-        position = this.getFirstDifferentPosition(current.reversedNumber, next.reversedNumber);
+        positionPrev = this.getFirstDifferentPosition(current.reversedNumber, prev.reversedNumber);
       }
 
+      if (idx !== matriculationNos.length - 1) {
+        const next = matriculationNos[idx + 1];
+        positionNext = this.getFirstDifferentPosition(current.reversedNumber, next.reversedNumber);
+      }
+
+      const position: number = Math.max(positionPrev, positionNext);
       const substring = this.reverseString(current.reversedNumber.substr(0, position + 1));
+
       result.push({
         studentId: current.id,
         shortenedNo: substring.padStart(7, '*'),
@@ -80,53 +85,5 @@ export abstract class PDFWithStudentsModule<T> extends PDFModule<T> {
       .split('')
       .reverse()
       .join('');
-  }
-
-  /**
-   * @deprecated // TODO: REMOVE ME
-   * Generates a matriculation number with the form "***123" where the first digits get replaced with "*". All students in the `students` array get a unique matriculation number. Therefore these "shortened" numbers are still enough to identify a student.
-   *
-   * @param student Student to generate the short matriculation number for.
-   * @param students All students to consider.
-   *
-   * @returns The shortened but still identifying number of the given student.
-   */
-  private shortOneMatriculationNumber(
-    student: StudentDocument,
-    students: StudentDocument[]
-  ): string {
-    if (!student.matriculationNo) {
-      throw new Error(`Student ${student.id} does not have a matriculation number.`);
-    }
-
-    const otherStudents = students.filter(s => s.id !== student.id);
-    const lengthOfNo = student.matriculationNo.length;
-
-    for (let iteration = 1; iteration < lengthOfNo; iteration++) {
-      const shortStudent = student.matriculationNo.substr(lengthOfNo - iteration, iteration);
-      let isOkay = true;
-
-      for (const otherStudent of otherStudents) {
-        if (!otherStudent.matriculationNo) {
-          continue;
-        }
-
-        const shortOtherStudent = otherStudent.matriculationNo.substr(
-          lengthOfNo - iteration,
-          iteration
-        );
-
-        if (shortStudent === shortOtherStudent) {
-          isOkay = false;
-          break;
-        }
-      }
-
-      if (isOkay) {
-        return shortStudent.padStart(7, '*');
-      }
-    }
-
-    return student.matriculationNo;
   }
 }

--- a/server/src/services/pdf-service/modules/ScheinResultsPDFModule.ts
+++ b/server/src/services/pdf-service/modules/ScheinResultsPDFModule.ts
@@ -19,10 +19,7 @@ export class ScheinResultsPDFModule extends PDFWithStudentsModule<GeneratorOptio
    *
    * @returns Buffer of a PDF containing the list with the schein status of all the given students.
    */
-  public async generatePDF({
-    students: givenStudents,
-    summaries,
-  }: GeneratorOptions): Promise<Buffer> {
+  public generatePDF({ students: givenStudents, summaries }: GeneratorOptions): Promise<Buffer> {
     const students = givenStudents.filter(student => !!student.matriculationNo);
     const shortenedMatriculationNumbers = this.getShortenedMatriculationNumbers(students);
 

--- a/server/src/services/pdf-service/modules/ScheinResultsPDFModule.ts
+++ b/server/src/services/pdf-service/modules/ScheinResultsPDFModule.ts
@@ -25,12 +25,10 @@ export class ScheinResultsPDFModule extends PDFWithStudentsModule<GeneratorOptio
 
     const tableRows: string[] = [];
 
-    this.sortShortenedMatriculationNumbers(shortenedMatriculationNumbers).forEach(
-      ([id, shortenedMatrNo]) => {
-        const passedString = summaries[id].passed ? '{{yes}}' : '{{no}}';
-        tableRows.push(`<tr><td>${shortenedMatrNo}</td><td>${passedString}</td></tr>`);
-      }
-    );
+    shortenedMatriculationNumbers.forEach(({ studentId, shortenedNo }) => {
+      const passedString = summaries[studentId].passed ? '{{yes}}' : '{{no}}';
+      tableRows.push(`<tr><td>${shortenedNo}</td><td>${passedString}</td></tr>`);
+    });
 
     const body = this.replacePlaceholdersInTemplate(tableRows);
     return this.generatePDFFromBody(body);

--- a/server/src/services/pdf-service/modules/ScheinexamResultPDFModule.ts
+++ b/server/src/services/pdf-service/modules/ScheinexamResultPDFModule.ts
@@ -43,12 +43,10 @@ export class ScheinexamResultPDFModule extends PDFWithStudentsModule<PDFGenerato
     const results = this.getResultsOfAllStudents({ exam, students });
 
     const rows: string[] = [];
-    this.sortShortenedMatriculationNumbers(shortenedMatriculationNumbers).forEach(
-      ([id, shortenedMatrNo]) => {
-        const passedState: ExamPassedState = results[id] ?? ExamPassedState.NOT_ATTENDED;
-        rows.push(`<tr><td>${shortenedMatrNo}</td><td>{{${passedState}}}</td></tr>`);
-      }
-    );
+    shortenedMatriculationNumbers.forEach(({ studentId, shortenedNo }) => {
+      const passedState: ExamPassedState = results[studentId] ?? ExamPassedState.NOT_ATTENDED;
+      rows.push(`<tr><td>${shortenedNo}</td><td>{{${passedState}}}</td></tr>`);
+    });
 
     const body = this.replacePlaceholdersInTemplate(rows, exam);
 

--- a/server/src/services/sheet-service/SheetService.class.ts
+++ b/server/src/services/sheet-service/SheetService.class.ts
@@ -1,4 +1,3 @@
-import { isDocument } from '@typegoose/typegoose';
 import { getPointsOfExercise, PointId, PointMap } from 'shared/dist/model/Points';
 import { Sheet, SheetDTO } from 'shared/dist/model/Sheet';
 import {
@@ -82,14 +81,8 @@ class SheetService {
     const pointsOfStudent = new PointMap(student.points);
     let pointsOfTeam = new PointMap();
 
-    if (student.team) {
-      if (!isDocument(student.team)) {
-        throw new Error(
-          '[SheetService] The team of a student must be a populated document if provided.'
-        );
-      }
-
-      pointsOfTeam = new PointMap(student.team.points);
+    if (student.teamDocument) {
+      pointsOfTeam = new PointMap(student.teamDocument.points);
     }
 
     let result = 0;

--- a/server/src/services/student-service/StudentService.class.ts
+++ b/server/src/services/student-service/StudentService.class.ts
@@ -60,6 +60,7 @@ class StudentService {
       cakeCount: 0,
       attendance: new Types.Map(),
       presentationPoints: new Types.Map(),
+      teamDocument: undefined,
     };
     const createdStudent = await StudentModel.create(studentData);
 
@@ -100,6 +101,7 @@ class StudentService {
       cakeCount: student.cakeCount,
       attendance: student.attendance,
       presentationPoints: student.presentationPoints,
+      teamDocument: undefined,
     };
 
     // Encrypt the student manually due to the encryption library not supporting 'updateOne()'.
@@ -301,6 +303,7 @@ class StudentService {
     }
 
     if (isDocument(student.team)) {
+      student.teamDocument = student.team;
       return student;
     }
 
@@ -309,7 +312,7 @@ class StudentService {
       getIdOfDocumentRef(student.team)
     );
 
-    student.team = team;
+    student.teamDocument = team;
 
     return student;
   }

--- a/server/src/services/student-service/StudentService.class.ts
+++ b/server/src/services/student-service/StudentService.class.ts
@@ -40,7 +40,9 @@ class StudentService {
   }
 
   public async getAllStudentsAsDocuments(): Promise<StudentDocument[]> {
-    return StudentModel.find();
+    return StudentModel.find()
+      .populate('team')
+      .exec();
   }
 
   public async createStudent({ tutorial: tutorialId, ...dto }: StudentDTO): Promise<Student> {
@@ -220,7 +222,7 @@ class StudentService {
       return this.rejectStudentNotFound();
     }
 
-    return student;
+    return student.populate('team').execPopulate();
   }
 
   public async getStudentOrReject(student: StudentDocument | null): Promise<Student> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5261,17 +5261,17 @@ formidable@^1.2.0:
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
   integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
-formik@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.0.8.tgz#a17740007a9a1394360142c128bb686acb5dbc7c"
-  integrity sha512-PxC9G6EvLdJzMv7z+bsvpI/Euplv2vVgTQebD5yNza4t3fiMBB+iD90VOVTLCyH5Pnv3bljsZiKsIqGp/UNKKg==
+formik@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.1.3.tgz#bd168011436393c8426a70cf8dfa5ddbbb95fd23"
+  integrity sha512-twK9sxWt+M2NSXxHBw6TiXNJ72iPVhgUUjeZMD8RYQC+VU7Hrxu6ElCz1xGmbT0q2DbHk4IxoupCkGEPwERzEA==
   dependencies:
     deepmerge "^2.1.1"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.14"
     lodash-es "^4.17.14"
     react-fast-compare "^2.0.1"
-    scheduler "^0.17.0"
+    scheduler "^0.18.0"
     tiny-warning "^1.0.2"
     tslib "^1.10.0"
 
@@ -10573,14 +10573,6 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
-
-scheduler@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
-  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.18.0:
   version "0.18.0"


### PR DESCRIPTION
# :ticket: Description
This PR solves the issue that the calculation of the schein statuses of all students slow down the TMS afterwards. It is achieved by streamlining the calculation process and greatly reducing the amount of needed asynchronous tasks (like fetching information from the DB).
<!-- Describe this PR -->

# :lock: Closes
- Closes #234 
- Closes #232 
<!-- Which issue(s) is (are) being closed by the PR? -->
