### PR TITLE
Fix slow loading of students due to gradings.

### DIFF
--- a/server/src/database/models/grading.model.ts
+++ b/server/src/database/models/grading.model.ts
@@ -7,7 +7,7 @@ import { StaticSettings } from '../../module/settings/settings.static';
 import { ExerciseGradingDTO, GradingDTO } from '../../module/student/student.dto';
 import { IExerciseGrading, IGrading } from '../../shared/model/Gradings';
 import { ExerciseDocument, SubExerciseDocument } from './exercise.model';
-import { StudentDocument, StudentModel } from './student.model';
+import { StudentDocument } from './student.model';
 
 export class ExerciseGradingModel {
   constructor({ points }: { points: number }) {
@@ -126,8 +126,8 @@ export class GradingModel {
   @prop()
   additionalPoints?: number;
 
-  @prop({ ref: StudentModel, autopopulate: true, default: [], index: true })
-  students!: StudentDocument[];
+  @prop({ default: [], index: true })
+  students!: string[];
 
   @prop()
   sheetId?: string;
@@ -172,10 +172,10 @@ export class GradingModel {
    * @param student Student to add to this grading.
    */
   addStudent(this: GradingDocument, student: StudentDocument): void {
-    const idx = this.students.findIndex((doc) => doc.id === student.id);
+    const idx = this.students.findIndex((docId) => docId === student.id);
 
     if (idx === -1) {
-      this.students.push(student);
+      this.students.push(student.id);
       this.markModified('students');
     }
   }

--- a/server/src/module/markdown/markdown.service.ts
+++ b/server/src/module/markdown/markdown.service.ts
@@ -207,7 +207,8 @@ export class MarkdownService {
       }
 
       gradings.forEach((grading) => {
-        const teamName = TeamModel.generateTeamname(grading.students);
+        const studentsOfTeam = team.students.filter((stud) => grading.students.includes(stud.id));
+        const teamName = TeamModel.generateTeamname(studentsOfTeam);
         const nameOfEntity = grading.belongsToTeam ? `Team ${teamName}` : `Student/in ${teamName}`;
 
         markdownData.push({


### PR DESCRIPTION
# :ticket: Description
This PR extends the idea described in #627: The GradingDocuments don't get put in an extra collection anymore. Every student holds their own gradings but each gradings has a reference to other students (in form of their IDs). Those IDs are used to update all related grading documents if one of those get updated.

This leads to a slight increase in the time needed to add / update a grading of a student. However loading all students will be faster if a lot of gradings have put down.
<!-- Describe this PR -->

# :lock: Closes
- #627 
- #663 
<!-- Which issue(s) is (are) being closed by the PR? -->
