### PR TITLE
Fix wrong sorting of tutorials

### DIFF
--- a/client/src/hooks/LoginService.helpers.ts
+++ b/client/src/hooks/LoginService.helpers.ts
@@ -1,0 +1,26 @@
+import { TutorialInEntity } from '../model/LoggedInUser';
+
+/**
+ * Compares the two given tutorials and returns the corresponding number.
+ *
+ * The comparison takes in three steps:
+ * 1. Compare by `weekday` (from monday to sunday)
+ * 2. If same weekday: Compare by start time
+ * 3. If same start time: Compare by slot name.
+ *
+ * @param a First tutorial
+ * @param b Second tutorial
+ *
+ * @returns Number that can be used for comparison.
+ */
+export function compareTutorials(a: TutorialInEntity, b: TutorialInEntity): number {
+  if (a.weekday !== b.weekday) {
+    return a.weekday - b.weekday;
+  }
+
+  if (!a.time.equals(b.time)) {
+    return a.time.start > b.time.start ? 1 : -1;
+  }
+
+  return a.slot.localeCompare(b.slot);
+}

--- a/client/src/hooks/LoginService.tsx
+++ b/client/src/hooks/LoginService.tsx
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import { plainToClass } from 'class-transformer';
 import React, { useContext, useState } from 'react';
 import { ILoggedInUser } from 'shared/model/User';
-import { LoggedInUser, TutorialInEntity } from '../model/LoggedInUser';
+import { LoggedInUser } from '../model/LoggedInUser';
 import { RequireChildrenProp } from '../typings/RequireChildrenProp';
 import { getUser, removeUser, saveUser } from '../util/userStorage';
 import axios from './fetching/Axios';
@@ -99,26 +99,7 @@ async function handleResponse(response: AxiosResponse<ILoggedInUser>): Promise<L
     return Promise.reject(response.statusText);
   }
 
-  const user = plainToClass(LoggedInUser, data);
-  user.tutorials.sort(sortTutorials);
-  user.tutorialsToCorrect.sort(sortTutorials);
-  user.substituteTutorials.sort(sortTutorials);
-
-  return user;
-}
-
-function sortTutorials(a: TutorialInEntity, b: TutorialInEntity): number {
-  if (a.weekday !== b.weekday) {
-    return a.weekday - b.weekday;
-  }
-
-  if (!a.time.equals(b.time)) {
-    a.time > b.time;
-
-    return a.time.start > b.time.start ? 1 : -1;
-  }
-
-  return a.slot.localeCompare(b.slot);
+  return plainToClass(LoggedInUser, data);
 }
 
 export function LoginContextProvider({ children }: RequireChildrenProp): JSX.Element {

--- a/client/src/hooks/LoginService.tsx
+++ b/client/src/hooks/LoginService.tsx
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import { plainToClass } from 'class-transformer';
 import React, { useContext, useState } from 'react';
 import { ILoggedInUser } from 'shared/model/User';
-import { LoggedInUser } from '../model/LoggedInUser';
+import { LoggedInUser, TutorialInEntity } from '../model/LoggedInUser';
 import { RequireChildrenProp } from '../typings/RequireChildrenProp';
 import { getUser, removeUser, saveUser } from '../util/userStorage';
 import axios from './fetching/Axios';
@@ -99,11 +99,26 @@ async function handleResponse(response: AxiosResponse<ILoggedInUser>): Promise<L
     return Promise.reject(response.statusText);
   }
 
-  data.tutorials.sort((a, b) => a.slot.localeCompare(b.slot));
-  data.tutorialsToCorrect.sort((a, b) => a.slot.localeCompare(b.slot));
-  data.substituteTutorials.sort((a, b) => a.slot.localeCompare(b.slot));
+  const user = plainToClass(LoggedInUser, data);
+  user.tutorials.sort(sortTutorials);
+  user.tutorialsToCorrect.sort(sortTutorials);
+  user.substituteTutorials.sort(sortTutorials);
 
-  return plainToClass(LoggedInUser, data);
+  return user;
+}
+
+function sortTutorials(a: TutorialInEntity, b: TutorialInEntity): number {
+  if (a.weekday !== b.weekday) {
+    return a.weekday - b.weekday;
+  }
+
+  if (!a.time.equals(b.time)) {
+    a.time > b.time;
+
+    return a.time.start > b.time.start ? 1 : -1;
+  }
+
+  return a.slot.localeCompare(b.slot);
 }
 
 export function LoginContextProvider({ children }: RequireChildrenProp): JSX.Element {

--- a/client/src/model/LoggedInUser.ts
+++ b/client/src/model/LoggedInUser.ts
@@ -1,18 +1,26 @@
 import { Transform, Type } from 'class-transformer';
-import { DateTime } from 'luxon';
-import { TutorialInEntity } from 'shared/model/Common';
+import { DateTime, Interval } from 'luxon';
+import { ITutorialInEntity } from 'shared/model/Common';
 import { Role } from 'shared/model/Role';
 import { ILoggedInUser } from 'shared/model/User';
 import { Modify } from '../typings/Modify';
 
 interface Modified {
+  tutorials: TutorialInEntity[];
+  tutorialsToCorrect: TutorialInEntity[];
   substituteTutorials: LoggedInSubstituteTutorial[];
 }
 
-class LoggedInSubstituteTutorial {
+export class TutorialInEntity implements Omit<ITutorialInEntity, 'time'> {
   readonly id!: string;
   readonly slot!: string;
+  readonly weekday!: number;
 
+  @Transform((value) => Interval.fromISO(value))
+  readonly time!: Interval;
+}
+
+class LoggedInSubstituteTutorial extends TutorialInEntity {
   @Transform((values: string[]) => values.map((val) => DateTime.fromISO(val)), {
     toClassOnly: true,
   })
@@ -23,9 +31,13 @@ export class LoggedInUser implements Modify<ILoggedInUser, Modified> {
   readonly id!: string;
   readonly firstname!: string;
   readonly lastname!: string;
-  readonly tutorials!: TutorialInEntity[];
-  readonly tutorialsToCorrect!: TutorialInEntity[];
   readonly roles!: Role[];
+
+  @Type(() => TutorialInEntity)
+  readonly tutorials!: TutorialInEntity[];
+
+  @Type(() => TutorialInEntity)
+  readonly tutorialsToCorrect!: TutorialInEntity[];
 
   hasTemporaryPassword!: boolean;
 

--- a/client/src/model/Student.ts
+++ b/client/src/model/Student.ts
@@ -1,7 +1,7 @@
 import { Transform, Type } from 'class-transformer';
 import { DateTime } from 'luxon';
 import { IAttendance } from 'shared/model/Attendance';
-import { HasId, TutorialInEntity } from 'shared/model/Common';
+import { HasId, ITutorialInEntity } from 'shared/model/Common';
 import { IStudent, StudentStatus, TeamInStudent } from 'shared/model/Student';
 import { getNameOfEntity } from 'shared/util/helpers';
 import { Modify } from '../typings/Modify';
@@ -38,7 +38,7 @@ export class Student implements Modify<IStudent, Modified> {
   readonly matriculationNo?: string;
   readonly status!: StudentStatus;
   readonly team?: TeamInStudent;
-  readonly tutorial!: TutorialInEntity;
+  readonly tutorial!: ITutorialInEntity;
 
   cakeCount!: number;
 

--- a/client/src/pages/AppBar.tsx
+++ b/client/src/pages/AppBar.tsx
@@ -22,11 +22,11 @@ import {
 import { useSnackbar } from 'notistack';
 import React, { useMemo, useState } from 'react';
 import { useRouteMatch } from 'react-router';
-import { TutorialInEntity } from 'shared/model/Common';
 import { useChangeTheme } from '../components/ContextWrapper';
 import SubmitButton from '../components/loading/SubmitButton';
 import { getTutorialXLSX } from '../hooks/fetching/Files';
 import { useLogin } from '../hooks/LoginService';
+import { TutorialInEntity } from '../model/LoggedInUser';
 import { Tutorial } from '../model/Tutorial';
 import { ROUTES } from '../routes/Routing.routes';
 import { saveBlob } from '../util/helperFunctions';

--- a/client/src/pages/dashboard/Dashboard.tsx
+++ b/client/src/pages/dashboard/Dashboard.tsx
@@ -34,9 +34,8 @@ async function getTutorialSummariesForUser(
   }
 
   const summaries: TutorialSummaryInfo[] = [];
-  const sortedTutorials = userData.tutorials.sort((a, b) => a.slot.localeCompare(b.slot));
 
-  for (const loggedInTutorial of sortedTutorials) {
+  for (const loggedInTutorial of userData.tutorials) {
     const tutorial = await getTutorial(loggedInTutorial.id);
     const studentInfos = await getScheinCriteriaSummariesOfAllStudentsOfTutorial(
       loggedInTutorial.id

--- a/client/src/pages/studentmanagement/student-list/components/TutorialChangeForm.tsx
+++ b/client/src/pages/studentmanagement/student-list/components/TutorialChangeForm.tsx
@@ -1,6 +1,6 @@
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { TutorialInEntity } from 'shared/model/Common';
+import { ITutorialInEntity } from 'shared/model/Common';
 import * as Yup from 'yup';
 import FormikSelect from '../../../../components/forms/components/FormikSelect';
 import FormikBaseForm, {
@@ -31,7 +31,7 @@ const validationSchema = Yup.object().shape({
 export type TutorialChangeFormSubmitCallback = FormikSubmitCallback<TutorialChangeFormState>;
 
 interface Props extends Omit<FormikBaseFormProps<TutorialChangeFormState>, CommonlyUsedFormProps> {
-  tutorial: TutorialInEntity;
+  tutorial: ITutorialInEntity;
   onSubmit: TutorialChangeFormSubmitCallback;
   onCancel: () => void;
 }

--- a/server/src/database/models/student.model.ts
+++ b/server/src/database/models/student.model.ts
@@ -238,7 +238,7 @@ export class StudentModel {
       lastname,
       iliasName,
       matriculationNo,
-      tutorial: { id: tutorial.id, slot: tutorial.slot },
+      tutorial: tutorial.toInEntity(),
       team: team && {
         id: team.id,
         teamNo: team.teamNo,

--- a/server/src/database/models/tutorial.model.ts
+++ b/server/src/database/models/tutorial.model.ts
@@ -1,9 +1,10 @@
 import { DocumentType, modelOptions, plugin, prop } from '@typegoose/typegoose';
-import { DateTime, ToISOTimeOptions } from 'luxon';
+import { DateTime, Interval, ToISOTimeOptions } from 'luxon';
 import { Schema } from 'mongoose';
 import mongooseAutoPopulate from 'mongoose-autopopulate';
 import { CollectionName } from '../../helpers/CollectionName';
 import { NoFunctions } from '../../helpers/NoFunctions';
+import { ITutorialInEntity } from '../../shared/model/Common';
 import { ITutorial } from '../../shared/model/Tutorial';
 import { StudentDocument } from './student.model';
 import { TeamDocument } from './team.model';
@@ -37,6 +38,10 @@ export class TutorialModel {
   }
 
   set dates(dates: DateTime[]) {
+    if (dates.length === 0) {
+      throw new Error('ERR_TUTORIAL_DATES_EMPTY');
+    }
+
     this._dates = dates
       .map((date) => date.toISODate())
       .filter((val): val is string => val !== null);
@@ -170,6 +175,15 @@ export class TutorialModel {
       })),
       substitutes: [...this.substitutes],
       teams: teams.map((team) => team.id),
+    };
+  }
+
+  toInEntity(this: TutorialDocument): ITutorialInEntity {
+    return {
+      id: this.id,
+      slot: this.slot,
+      weekday: this.dates[0].weekday,
+      time: Interval.fromDateTimes(this.startTime, this.endTime).toISO(),
     };
   }
 

--- a/server/src/database/models/user.model.ts
+++ b/server/src/database/models/user.model.ts
@@ -101,14 +101,8 @@ export class UserModel {
       roles: [...roles],
       email,
       temporaryPassword,
-      tutorials: tutorials.map((tutorial) => ({
-        id: tutorial.id,
-        slot: tutorial.slot,
-      })),
-      tutorialsToCorrect: tutorialsToCorrect.map((tutorial) => ({
-        id: tutorial.id,
-        slot: tutorial.slot,
-      })),
+      tutorials: tutorials.map((tutorial) => tutorial.toInEntity()),
+      tutorialsToCorrect: tutorialsToCorrect.map((tutorial) => tutorial.toInEntity()),
     };
   }
 }

--- a/server/src/module/user/user.service.ts
+++ b/server/src/module/user/user.service.ts
@@ -327,8 +327,7 @@ export class UserService implements OnModuleInit, CRUDService<IUser, UserDTO, Us
 
         const date = DateTime.fromISO(dateKey).toISODate();
         const substInfo: ILoggedInUserSubstituteTutorial = substituteTutorials.get(tutorial.id) ?? {
-          id: tutorial.id,
-          slot: tutorial.slot,
+          ...tutorial.toInEntity(),
           dates: [],
         };
 

--- a/server/src/shared/model/Common.ts
+++ b/server/src/shared/model/Common.ts
@@ -7,6 +7,10 @@ export interface NamedElement extends HasId {
   readonly lastname: string;
 }
 
-export interface TutorialInEntity extends HasId {
+export interface ITutorialInEntity extends HasId {
   readonly slot: string;
+  readonly weekday: number;
+
+  /** Start and endtime in the form of a luxon interval. */
+  readonly time: string;
 }

--- a/server/src/shared/model/Student.ts
+++ b/server/src/shared/model/Student.ts
@@ -1,5 +1,5 @@
 import { IAttendance } from './Attendance';
-import { HasId, NamedElement, TutorialInEntity } from './Common';
+import { HasId, ITutorialInEntity, NamedElement } from './Common';
 import { IGrading } from './Gradings';
 
 export interface TeamInStudent extends HasId {
@@ -22,7 +22,7 @@ export interface IStudent extends NamedElement {
   presentationPoints: [string, number][];
   status: StudentStatus;
   team?: TeamInStudent;
-  tutorial: TutorialInEntity;
+  tutorial: ITutorialInEntity;
   cakeCount: number;
 }
 

--- a/server/src/shared/model/User.ts
+++ b/server/src/shared/model/User.ts
@@ -1,21 +1,21 @@
-import { NamedElement, TutorialInEntity } from './Common';
+import { ITutorialInEntity, NamedElement } from './Common';
 import { Role } from './Role';
 
-export interface ILoggedInUserSubstituteTutorial extends TutorialInEntity {
+export interface ILoggedInUserSubstituteTutorial extends ITutorialInEntity {
   dates: string[];
 }
 
 export interface ILoggedInUser extends NamedElement {
-  tutorials: TutorialInEntity[];
-  tutorialsToCorrect: TutorialInEntity[];
+  tutorials: ITutorialInEntity[];
+  tutorialsToCorrect: ITutorialInEntity[];
   roles: IUser['roles'];
   hasTemporaryPassword: boolean;
   substituteTutorials: ILoggedInUserSubstituteTutorial[];
 }
 
 export interface IUser extends NamedElement {
-  readonly tutorials: TutorialInEntity[];
-  readonly tutorialsToCorrect: TutorialInEntity[];
+  readonly tutorials: ITutorialInEntity[];
+  readonly tutorialsToCorrect: ITutorialInEntity[];
   readonly roles: Role[];
   readonly username: string;
   readonly email: string;


### PR DESCRIPTION
# :ticket: Description
This fixes that the tutorials got sorted on the client side only by slot. Tutorials now get sorted by `weekday?  first, by `startTime` second and by `slot` last.

<!-- Describe this PR -->

# :lock: Closes
- Closes #705 
<!-- Which issue(s) is (are) being closed by the PR? -->
