### PR TITLE
Fix team during student creation always stays at create new team

### DIFF
--- a/client/src/components/TeamTableRow.tsx
+++ b/client/src/components/TeamTableRow.tsx
@@ -2,9 +2,9 @@ import { TableCell, Theme, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { AccountMultiple as GroupIcon } from 'mdi-material-ui';
 import React from 'react';
+import { Team } from '../model/Team';
 import EntityListItemMenu from './list-item-menu/EntityListItemMenu';
 import PaperTableRow, { PaperTableRowProps } from './PaperTableRow';
-import { Team } from '../model/Team';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -49,7 +49,7 @@ function TeamTableRow({
             <Typography>
               {team.students.length > 0
                 ? `Mitglieder: ${team.students
-                    .map((student) => `${student.firstname} ${student.lastname}`)
+                    .map((student) => student.nameFirstnameFirst)
                     .join(', ')}`
                 : 'Keine Mitglieder.'}
             </Typography>

--- a/client/src/components/forms/StudentForm.tsx
+++ b/client/src/components/forms/StudentForm.tsx
@@ -1,7 +1,6 @@
 import { FormikHelpers } from 'formik';
 import React, { useMemo, useRef } from 'react';
 import { IStudentDTO, StudentStatus } from 'shared/model/Student';
-import { getNameOfEntity } from 'shared/util/helpers';
 import * as Yup from 'yup';
 import { useSettings } from '../../hooks/useSettings';
 import { Student } from '../../model/Student';
@@ -250,9 +249,7 @@ function StudentForm({
 
               for (const s of otherStudents) {
                 if (s.matriculationNo && value === s.matriculationNo) {
-                  return `Matrikelnummer wird bereits von ${getNameOfEntity(s, {
-                    firstNameFirst: true,
-                  })} verwendet.`;
+                  return `Matrikelnummer wird bereits von ${s.nameFirstnameFirst} verwendet.`;
                 }
               }
 

--- a/client/src/components/forms/StudentForm.tsx
+++ b/client/src/components/forms/StudentForm.tsx
@@ -209,6 +209,7 @@ function StudentForm({
         initialValues={initialFormState}
         validationSchema={validationSchema}
         onSubmit={handleSubmit}
+        enableReinitialize
         enableDebug
       >
         <FormikTextField name='firstname' label='Vorname' inputRef={firstnameInputRef} required />

--- a/client/src/components/forms/TeamForm.tsx
+++ b/client/src/components/forms/TeamForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Student } from '../../model/Student';
+import { StudentInTeam } from '../../model/Student';
 import { Team } from '../../model/Team';
 import { FormikSubmitCallback } from '../../types';
 import FormikFilterableSelect from './components/FormikFilterableSelect';
@@ -16,7 +16,7 @@ interface TeamFormState {
 interface Props extends Omit<FormikBaseFormProps<TeamFormState>, CommonlyUsedFormProps> {
   team?: Team;
   onSubmit: TeamFormSubmitCallback;
-  students: Student[];
+  students: StudentInTeam[];
 }
 
 function getInitialFormState(team?: Team): TeamFormState {
@@ -44,7 +44,7 @@ function TeamForm({ students, onSubmit, team, ...other }: Props): JSX.Element {
         emptyPlaceholder='Keine Studierenden vorhanden.'
         filterPlaceholder='Suche nach Namen'
         items={students}
-        itemToString={(student) => `${student.lastname}, ${student.firstname}`}
+        itemToString={(student) => student.name}
         itemToValue={(student) => student.id}
         minHeight={400}
         gridColumn='1 / span 2'

--- a/client/src/hooks/fetching/Team.ts
+++ b/client/src/hooks/fetching/Team.ts
@@ -5,9 +5,7 @@ import { Team } from '../../model/Team';
 import axios from './Axios';
 
 function sortStudentsOfTeam(team: Team) {
-  team.students.sort((a, b) =>
-    `${a.lastname}, ${a.firstname}`.localeCompare(`${b.lastname}, ${b.firstname}`)
-  );
+  team.students.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function getTeamsOfTutorial(tutorialId: string): Promise<Team[]> {

--- a/client/src/model/Student.ts
+++ b/client/src/model/Student.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import { IAttendance } from 'shared/model/Attendance';
 import { HasId, ITutorialInEntity } from 'shared/model/Common';
 import { IStudent, StudentStatus, TeamInStudent } from 'shared/model/Student';
+import { IStudentInTeam } from 'shared/model/Team';
 import { getNameOfEntity } from 'shared/util/helpers';
 import { Modify } from '../typings/Modify';
 import { HasGradings } from '../typings/types';
@@ -16,7 +17,7 @@ interface Modified extends HasGradings {
   gradings: Map<string, Grading>;
 }
 
-export class Student implements Modify<IStudent, Modified> {
+export class StudentInTeam implements Modify<IStudentInTeam, Modified> {
   readonly id!: string;
   readonly firstname!: string;
   readonly lastname!: string;
@@ -38,7 +39,6 @@ export class Student implements Modify<IStudent, Modified> {
   readonly matriculationNo?: string;
   readonly status!: StudentStatus;
   readonly team?: TeamInStudent;
-  readonly tutorial!: ITutorialInEntity;
 
   cakeCount!: number;
 
@@ -120,4 +120,8 @@ export class Student implements Modify<IStudent, Modified> {
 
     return `Team ${this.team.teamNo.toString().padStart(2, '0')}`;
   }
+}
+
+export class Student extends StudentInTeam implements Modify<IStudent, Modified> {
+  readonly tutorial!: ITutorialInEntity;
 }

--- a/client/src/model/Team.ts
+++ b/client/src/model/Team.ts
@@ -4,10 +4,10 @@ import { ITeam } from 'shared/model/Team';
 import { Modify } from '../typings/Modify';
 import { HasGradings } from '../typings/types';
 import { Grading } from './Grading';
-import { Student } from './Student';
+import { StudentInTeam } from './Student';
 
 interface Modified extends HasGradings {
-  students: Student[];
+  students: StudentInTeam[];
 }
 
 export class Team implements Modify<ITeam, Modified> {
@@ -15,8 +15,8 @@ export class Team implements Modify<ITeam, Modified> {
   readonly teamNo!: number;
   readonly tutorial!: string;
 
-  @Type(() => Student)
-  readonly students!: Student[];
+  @Type(() => StudentInTeam)
+  readonly students!: StudentInTeam[];
 
   /**
    * Returns the grading assigned to this team for the given entity.

--- a/client/src/pages/attendance/components/StudentsAttendanceRow.tsx
+++ b/client/src/pages/attendance/components/StudentsAttendanceRow.tsx
@@ -47,7 +47,7 @@ function StudentAttendanceRow({
 
   return (
     <PaperTableRow
-      label={`${student.lastname}, ${student.firstname}`}
+      label={student.name}
       subText={
         student.team ? `Team: #${student.team.teamNo.toString().padStart(2, '0')}` : 'Kein Team'
       }

--- a/client/src/pages/import-short-tests/components/map-students-ilias-names/MapStudentsToIliasNames.tsx
+++ b/client/src/pages/import-short-tests/components/map-students-ilias-names/MapStudentsToIliasNames.tsx
@@ -135,7 +135,7 @@ function MapStudentsToIliasNames(): JSX.Element {
                             <Chip
                               label={
                                 mappedStudent
-                                  ? getNameOfEntity(mappedStudent)
+                                  ? mappedStudent.name
                                   : 'Kein/e Studierende/r zugeordnet'
                               }
                               className={mappedStudent ? classes.chipOkay : classes.chipError}

--- a/client/src/pages/import-short-tests/components/map-students-ilias-names/MappingDialog.tsx
+++ b/client/src/pages/import-short-tests/components/map-students-ilias-names/MappingDialog.tsx
@@ -1,7 +1,6 @@
 import { Box, Typography } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React, { useEffect } from 'react';
-import { getNameOfEntity } from 'shared/util/helpers';
 import FilterableSelect from '../../../../components/forms/components/FilterableSelect';
 import { SelectionDialogChildrenProps } from '../../../../hooks/dialog-service/components/SelectionDialogContent';
 import { Student } from '../../../../model/Student';
@@ -52,7 +51,7 @@ function MappingDialog({
         emptyPlaceholder='Keine Studierenden vorhanden.'
         filterPlaceholder='Suche nach Namen'
         items={students}
-        itemToString={(student) => getNameOfEntity(student)}
+        itemToString={(student) => student.name}
         itemToValue={(student) => student.id}
         value={selected ? [selected.id] : []}
         onChange={(newValue) => {

--- a/client/src/pages/points-scheinexam/overview/components/StudentCard.tsx
+++ b/client/src/pages/points-scheinexam/overview/components/StudentCard.tsx
@@ -3,7 +3,6 @@ import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { Account as StudentIcon } from 'mdi-material-ui';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { getNameOfEntity } from 'shared/util/helpers';
 import PointsTable from '../../../../components/points-table/PointsTable';
 import { Scheinexam } from '../../../../model/Scheinexam';
 import { Student } from '../../../../model/Student';
@@ -29,7 +28,7 @@ function StudentCard({ student, exam, pathTo }: Props): JSX.Element {
     <Card variant='outlined'>
       <CardHeader
         avatar={<StudentIcon />}
-        title={getNameOfEntity(student)}
+        title={student.name}
         subheader={student.getTeamString()}
       />
 

--- a/client/src/pages/points-sheet/enter-form/EnterStudentPoints.tsx
+++ b/client/src/pages/points-sheet/enter-form/EnterStudentPoints.tsx
@@ -2,11 +2,10 @@ import { Typography } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router';
 import { IGradingDTO } from 'shared/model/Gradings';
-import { getNameOfEntity } from 'shared/util/helpers';
 import { getStudent, setPointsOfStudent } from '../../../hooks/fetching/Student';
 import { getTeamOfTutorial } from '../../../hooks/fetching/Team';
 import { useCustomSnackbar } from '../../../hooks/snackbar/useCustomSnackbar';
-import { Student } from '../../../model/Student';
+import { Student, StudentInTeam } from '../../../model/Student';
 import { Team } from '../../../model/Team';
 import { ROUTES } from '../../../routes/Routing.routes';
 import { PointsFormSubmitCallback } from './components/EnterPointsForm.helpers';
@@ -93,17 +92,20 @@ function EnterStudentPoints(): JSX.Element {
       setStudent(updatedStudent);
 
       resetForm({ values: { ...values } });
-      enqueueSnackbar(`Punkte für ${getNameOfEntity(student)} erfolgreich eingetragen.`, {
+      enqueueSnackbar(`Punkte für ${student.nameFirstnameFirst} erfolgreich eingetragen.`, {
         variant: 'success',
       });
     } catch {
-      enqueueSnackbar(`Punkte für ${getNameOfEntity(student)} konnten nicht eingetragen werden.`, {
-        variant: 'error',
-      });
+      enqueueSnackbar(
+        `Punkte für ${student.nameFirstnameFirst} konnten nicht eingetragen werden.`,
+        {
+          variant: 'error',
+        }
+      );
     }
   };
 
-  const allStudents: Student[] = team ? team.students : student ? [student] : [];
+  const allStudents: StudentInTeam[] = team ? team.students : student ? [student] : [];
 
   return (
     <EnterPoints
@@ -115,7 +117,7 @@ function EnterStudentPoints(): JSX.Element {
       entitySelectProps={{
         label: 'Student',
         emptyPlaceholder: 'Keine Studierenden verfügbar.',
-        itemToString: (s) => getNameOfEntity(s),
+        itemToString: (s) => s.name,
         onChange: handleStudentChange,
       }}
     />

--- a/client/src/pages/points-sheet/overview/components/TeamCard.tsx
+++ b/client/src/pages/points-sheet/overview/components/TeamCard.tsx
@@ -19,7 +19,6 @@ import {
 } from 'mdi-material-ui';
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { getNameOfEntity } from 'shared/util/helpers';
 import EntityListItemMenu from '../../../../components/list-item-menu/EntityListItemMenu';
 import PointsTable from '../../../../components/points-table/PointsTable';
 import SplitButton from '../../../../components/SplitButton';
@@ -52,10 +51,6 @@ interface Props {
   onGeneratePdfClicked: (team: Team) => void;
 }
 
-function teamToString(team: Team): string {
-  return `Team #${team.getTeamNoAsString()}`;
-}
-
 function TeamCard({
   tutorialId,
   team,
@@ -77,9 +72,7 @@ function TeamCard({
 
   const studentsInTeam: string =
     team.students.length > 0
-      ? team.students
-          .map((student) => getNameOfEntity(student, { firstNameFirst: true }))
-          .join(', ')
+      ? team.students.map((student) => student.nameFirstnameFirst).join(', ')
       : 'Keine Studierende in diesem Team.';
 
   const { placeholderText, pdfDisabled } = useMemo(() => {
@@ -118,10 +111,7 @@ function TeamCard({
                   <StudentIcon />
                 </ListItemIcon>
 
-                <ListItemText
-                  primary={getNameOfEntity(student)}
-                  secondary='Zum Auswählen klicken'
-                />
+                <ListItemText primary={student.name} secondary='Zum Auswählen klicken' />
               </ListItem>
               {idx !== team.students.length - 1 && <Divider />}
             </React.Fragment>
@@ -161,7 +151,7 @@ function TeamCard({
             ]}
           />
         }
-        title={teamToString(team)}
+        title={`Team #${team.getTeamNoAsString()}`}
         subheader={studentsInTeam}
       />
 

--- a/client/src/pages/student-info/StudentInfo.tsx
+++ b/client/src/pages/student-info/StudentInfo.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import { AttendanceState, IAttendance, IAttendanceDTO } from 'shared/model/Attendance';
 import { ScheinCriteriaSummary } from 'shared/model/ScheinCriteria';
-import { getNameOfEntity } from 'shared/util/helpers';
 import BackButton from '../../components/back-button/BackButton';
 import Placeholder from '../../components/Placeholder';
 import TabPanel from '../../components/TabPanel';
@@ -165,7 +164,7 @@ function StudentInfo(): JSX.Element {
           className={classes.backButton}
         />
 
-        <Typography variant='h4'>{student && getNameOfEntity(student)}</Typography>
+        <Typography variant='h4'>{student?.name}</Typography>
 
         <ScheinStatusBox scheinStatus={scheinStatus} marginLeft='auto' />
       </Box>

--- a/client/src/pages/studentmanagement/student-list/StudentList.helpers.ts
+++ b/client/src/pages/studentmanagement/student-list/StudentList.helpers.ts
@@ -4,7 +4,7 @@ import { useSnackbar } from 'notistack';
 import { useCallback, useState } from 'react';
 import { ScheincriteriaSummaryByStudents } from 'shared/model/ScheinCriteria';
 import { IStudentDTO, StudentStatus } from 'shared/model/Student';
-import { getNameOfEntity, sortByName } from 'shared/util/helpers';
+import { sortByName } from 'shared/util/helpers';
 import { CREATE_NEW_TEAM_VALUE } from '../../../components/forms/StudentForm';
 import {
   getScheinCriteriaSummariesOfAllStudentsOfTutorial,
@@ -199,9 +199,7 @@ export function getFilteredStudents(
         return true;
       }
 
-      const name = getNameOfEntity(s);
-
-      return unifyFilterableText(name).includes(unifyFilterableText(filterText));
+      return unifyFilterableText(s.name).includes(unifyFilterableText(filterText));
     })
     .sort((a, b) => {
       switch (sortOption) {

--- a/client/src/pages/teamoverview/Teamoverview.tsx
+++ b/client/src/pages/teamoverview/Teamoverview.tsx
@@ -12,7 +12,7 @@ import { useDialog } from '../../hooks/dialog-service/DialogService';
 import { getStudent } from '../../hooks/fetching/Student';
 import { createTeam, deleteTeam, editTeam, getTeamsOfTutorial } from '../../hooks/fetching/Team';
 import { getStudentsOfTutorial } from '../../hooks/fetching/Tutorial';
-import { Student } from '../../model/Student';
+import { StudentInTeam } from '../../model/Student';
 import { Team } from '../../model/Team';
 import { useLogger } from '../../util/Logger';
 
@@ -40,9 +40,9 @@ interface Params {
 type Props = WithSnackbarProps & RouteComponentProps<Params>;
 
 function updateStudentsArray(
-  studentsToUpdate: Student[],
-  students: Student[],
-  setStudents: React.Dispatch<React.SetStateAction<Student[]>>
+  studentsToUpdate: StudentInTeam[],
+  students: StudentInTeam[],
+  setStudents: React.Dispatch<React.SetStateAction<StudentInTeam[]>>
 ) {
   const updatedStudents = [...students];
 
@@ -64,7 +64,7 @@ function Teamoverview({ enqueueSnackbar, match }: Props): JSX.Element {
   const logger = useLogger('Teamoverview');
 
   const [isLoading, setIsLoading] = useState(false);
-  const [students, setStudents] = useState<Student[]>([]);
+  const [students, setStudents] = useState<StudentInTeam[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
 
   useEffect(() => {

--- a/server/src/database/models/student.model.ts
+++ b/server/src/database/models/student.model.ts
@@ -8,6 +8,7 @@ import { StaticSettings } from '../../module/settings/settings.static';
 import { IAttendance } from '../../shared/model/Attendance';
 import { IGrading } from '../../shared/model/Gradings';
 import { IStudent, StudentStatus } from '../../shared/model/Student';
+import { IStudentInTeam } from '../../shared/model/Team';
 import { AttendanceDocument, AttendanceModel } from './attendance.model';
 import { HandInDocument } from './exercise.model';
 import { Grading } from './grading.model';
@@ -204,6 +205,16 @@ export class StudentModel {
    * @returns The DTO representation of this document.
    */
   toDTO(this: StudentDocument): IStudent {
+    return {
+      ...this.toStudentInTeam(),
+      tutorial: this.tutorial.toInEntity(),
+    };
+  }
+
+  /**
+   * @returns The representation of this document being used in a team.
+   */
+  toStudentInTeam(this: StudentDocument): IStudentInTeam {
     this.decryptFieldsSync();
 
     const {
@@ -213,7 +224,6 @@ export class StudentModel {
       iliasName,
       matriculationNo,
       cakeCount,
-      tutorial,
       email,
       courseOfStudies,
       status,
@@ -238,7 +248,6 @@ export class StudentModel {
       lastname,
       iliasName,
       matriculationNo,
-      tutorial: tutorial.toInEntity(),
       team: team && {
         id: team.id,
         teamNo: team.teamNo,

--- a/server/src/database/models/team.model.ts
+++ b/server/src/database/models/team.model.ts
@@ -77,7 +77,7 @@ export class TeamModel {
 
     return {
       id,
-      students: students.map((s) => s.toDTO()),
+      students: students.map((s) => s.toStudentInTeam()),
       teamNo,
       tutorial: tutorial.id,
     };

--- a/server/src/shared/model/Team.ts
+++ b/server/src/shared/model/Team.ts
@@ -6,8 +6,10 @@ export interface ITeamId {
   teamId: string;
 }
 
+export type IStudentInTeam = Omit<IStudent, 'tutorial'>;
+
 export interface ITeam extends HasId {
-  students: IStudent[];
+  students: IStudentInTeam[];
   teamNo: number;
   tutorial: string;
 }


### PR DESCRIPTION
# :ticket: Description

This fixes the issue described in #706.

Furthermore this PR removes the `tutorial` attribute from the students in a teams response because the information is already present in the "wrapping" team. More information can be found in the related commit 1631d489505cdb94b2ddce894ddb6df6f2f1c2d9.
<!-- Describe this PR -->

# :lock: Closes
- Closes #706
<!-- Which issue(s) is (are) being closed by the PR? -->
