### PR TITLE
Fix github-markdown-css being a devDependency.

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -12,6 +12,6 @@
 
 ## 🛠 Configuration
 
-**Configuration files** for the can be found [in the v2.1.0 release](https://github.com/Dudrie/Tutor-Management-System/releases/download/2.1.0/config_2.1.0.zip). Information about the **environment variables** can be found on the [Configuration wiki page](https://github.com/Dudrie/Tutor-Management-System/wiki/Configuration#environment-variables).
+**Configuration files** for this release can be found [in the v2.1.0 release](https://github.com/Dudrie/Tutor-Management-System/releases/download/2.1.0/config_2.1.0.zip). Information about the **environment variables** can be found on the [Configuration page](https://dudrie.github.io/Tutor-Management-System/docs/setup/configuration#environment-variables) of the documentation.
 
 <!-- Include a link to the current config files OR a note that this release contains new config files. -->

--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
     "upgrade-pkg:client": "cd ./client && npm-upgrade",
     "upgrade-pkg:server": "cd ./server && npm-upgrade"
   },
+  "dependencies": {
+    "class-transformer": "^0.3.1",
+    "github-markdown-css": "^4.0.0",
+    "lodash": "^4.17.20",
+    "luxon": "^1.25.0",
+    "markdown-it": "^12.0.1"
+  },
   "devDependencies": {
     "@prettier/plugin-pug": "^1.10.1",
     "@types/lodash": "^4.14.165",
@@ -41,16 +48,9 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "github-markdown-css": "^4.0.0",
     "jest-circus": "^26.6.3",
     "prettier": "^2.1.2",
     "ts-node": "^9.0.0",
     "typescript": "^3.9.7"
-  },
-  "dependencies": {
-    "class-transformer": "^0.3.1",
-    "lodash": "^4.17.20",
-    "luxon": "^1.25.0",
-    "markdown-it": "^12.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "workspaces": [
     "client",
     "server",


### PR DESCRIPTION
# :ticket: Description

The `github-markdown-css` package was listed as a devDependency and therefore was not installed properly in the production image.
<!-- Describe this PR -->

<!-- # :lock: Closes -->
<!-- Which issue(s) is (are) being closed by the PR? -->
