### PR TITLE
Fix TeamCards not showing grading if team has only one student.

### DIFF
--- a/build-docker-image.ts
+++ b/build-docker-image.ts
@@ -8,7 +8,7 @@ interface ArgumentOptions {
   hasValue?: boolean;
 }
 
-const DEFAULT_IMAGE_NAME = 'dudrie/tutor-management-system';
+const DEFAULT_IMAGE_NAME = 'ghcr.io/dudrie/tutor-management-system';
 
 function getArgValue({ name, short, hasValue }: ArgumentOptions): string | undefined {
   const args = process.argv;

--- a/client/src/model/Team.ts
+++ b/client/src/model/Team.ts
@@ -35,6 +35,10 @@ export class Team implements Modify<ITeam, Modified> {
       return undefined;
     }
 
+    if (gradings.length === 1) {
+      return gradings[0];
+    }
+
     return gradings.filter((grading) => grading.belongsToTeam)[0];
   }
 
@@ -65,10 +69,16 @@ export class Team implements Modify<ITeam, Modified> {
     return [...gradings.values()];
   }
 
+  /**
+   * @returns Team number as unified string with leading 0 if necessary.
+   */
   getTeamNoAsString(): string {
     return this.teamNo.toString().padStart(2, '0');
   }
 
+  /**
+   * @returns Team name with unified team number and the lastnames of the students of the team.
+   */
   toString(): string {
     const studentsInTeam = this.students.length
       ? `(${this.students.map((student) => student.lastname).join(', ')})`


### PR DESCRIPTION
# :ticket: Description

The team's `getGrading()` function did not return a grading properly if the team only has one student.
<!-- Describe this PR -->

# :lock: Closes

- Closes #806 
<!-- Which issue(s) is (are) being closed by the PR? -->
