### PR TITLE
Change font of markdown textfield to Roboto Mono (monospaced font).

### DIFF
--- a/client/public/index.pug
+++ b/client/public/index.pug
@@ -12,7 +12,13 @@ html(lang=en)
     // Global variables
     // #{GLOBAL_VARS}
 
+    link(rel='preconnect', href='https://fonts.gstatic.com')
     link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Roboto:300,400,500')
+    link(
+      rel='stylesheet',
+      href='https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500&display=swap'
+    )
+
     title Tutor Management System
   body
     noscript You need to enable JavaScript to run this app.

--- a/client/src/components/forms/components/FormikMarkdownTextfield.tsx
+++ b/client/src/components/forms/components/FormikMarkdownTextfield.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme: Theme) =>
     textField: {
       flex: 1,
       alignItems: 'flex-start',
+      fontFamily: '"Roboto Mono", monospace',
     },
   })
 );


### PR DESCRIPTION
# :ticket: Description

Changes the font of the markdown input textfield to a monospaced font for better readability (especially for code parts).
<!-- Describe this PR -->

# :lock: Closes
- Closes #862 
<!-- Which issue(s) is (are) being closed by the PR? -->
