### PR TITLE
Fix timout on setting gradings of multiple students.

### DIFF
--- a/client/src/hooks/fetching/Student.ts
+++ b/client/src/hooks/fetching/Student.ts
@@ -69,7 +69,8 @@ export async function setAttendanceOfStudent(
 }
 
 export async function setPointsOfMultipleStudents(points: Map<string, IGradingDTO>): Promise<void> {
-  const response = await axios.put('student/grading', [...points]);
+  // Timeout = 0 to prevent the request from timeouting.
+  const response = await axios.put('student/grading', [...points], { timeout: 0 });
 
   if (response.status !== 204) {
     return Promise.reject(`Wrong status code (${response.status}).`);


### PR DESCRIPTION
# :ticket: Description
The request on setting the gradings of multiple students (ie importing short test results) could timeout in some occasions. However, the server is correctly processing the request - it just takes a little longer - so it must not timeout.
<!-- Describe this PR -->

