### PR TITLE
Fix tutorials not being sorted by date on the tutorial management page.

### DIFF
--- a/client/snowpack.config.js
+++ b/client/snowpack.config.js
@@ -1,66 +1,66 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const httpProxy = require('http-proxy');
 const apiProxy = httpProxy.createServer({
-  target: 'http://localhost:8080',
-  // Don't verify the SSL certs (not needed during development)
-  secure: false,
-  // Change the URL of the request to match the target (and not the one of the client dev server)
-  changeOrigin: true,
+    target: 'http://localhost:8080',
+    // Don't verify the SSL certs (not needed during development)
+    secure: false,
+    // Change the URL of the request to match the target (and not the one of the client dev server)
+    changeOrigin: true,
 });
 
 /** @type { import("snowpack").SnowpackUserConfig } */
 module.exports = {
-  root: './',
-  mount: {
-    public: '/',
-    src: '/_dist_',
-    '../server/src/shared': '/shared',
-  },
-  routes: [
-    {
-      src: '/api/.*',
-      dest: (req, res) => apiProxy.web(req, res),
+    root: './',
+    mount: {
+        public: '/',
+        src: '/_dist_',
+        '../server/src/shared': '/shared',
     },
-    {
-      match: 'routes',
-      src: '.*',
-      dest: '/index.html',
-    },
-  ],
-  plugins: [
-    '@snowpack/plugin-react-refresh',
-    '@snowpack/plugin-dotenv',
-    [
-      './plugins/snowpack-pug.js',
-      {
-        file: 'index.pug',
-        locals: {
-          dev: { ROUTE_PREFIX: '' },
-          build: { ROUTE_PREFIX: '${ROUTE_PREFIX}' },
+    routes: [
+        {
+            src: '/api/.*',
+            dest: (req, res) => apiProxy.web(req, res),
         },
-      },
+        {
+            match: 'routes',
+            src: '.*',
+            dest: '/index.html',
+        },
     ],
-    '@snowpack/plugin-typescript',
-    [
-      '@snowpack/plugin-webpack',
-      {
-        // We need to keep comments in the HTML to support the prefix option of the server.
-        htmlMinifierOptions: { removeComments: false },
-      },
+    plugins: [
+        '@snowpack/plugin-react-refresh',
+        '@snowpack/plugin-dotenv',
+        [
+            './plugins/snowpack-pug.js',
+            {
+                file: 'index.pug',
+                locals: {
+                    dev: { ROUTE_PREFIX: '' },
+                    build: { ROUTE_PREFIX: '${ROUTE_PREFIX}' },
+                },
+            },
+        ],
+        '@snowpack/plugin-typescript',
+        [
+            '@snowpack/plugin-webpack',
+            {
+                // We need to keep comments in the HTML to support the prefix option of the server.
+                htmlMinifierOptions: { removeComments: false },
+            },
+        ],
+        ['./plugins/snowpack-prefix-support.js', { prefix: '${ROUTE_PREFIX}' }],
     ],
-    ['./plugins/snowpack-prefix-support.js', { prefix: '${ROUTE_PREFIX}' }],
-  ],
-  alias: {
-    shared: '../server/src/shared',
-  },
-  devOptions: {
-    port: 3000,
-    open: 'none',
-  },
-  packageOptions: {
-    polyfillNode: true,
-    namedExports: ['class-transformer', 'lodash'],
-    knownEntrypoints: [],
-  },
-  buildOptions: {},
+    alias: {
+        shared: '../server/src/shared',
+    },
+    devOptions: {
+        port: 3000,
+        open: 'none',
+    },
+    packageOptions: {
+        polyfillNode: true,
+        namedExports: ['class-transformer', 'lodash'],
+        knownEntrypoints: [],
+    },
+    buildOptions: {},
 };

--- a/client/src/components/markdown/Markdown.tsx
+++ b/client/src/components/markdown/Markdown.tsx
@@ -67,7 +67,7 @@ function Markdown({ markdown, html: htmlFromProps, className, ...props }: Props)
         [htmlFromProps, logger]
     );
 
-    const { value: html, execute, isLoading } = useFetchState({
+    const [html, isLoading, , execute] = useFetchState({
         fetchFunction,
         immediate: false,
     });

--- a/client/src/hooks/useFetchState.ts
+++ b/client/src/hooks/useFetchState.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 
-type BaseArrayType = readonly unknown[];
+export type BaseArrayType = readonly unknown[];
 
 interface UseFetchStateParamsDelayed<T, P extends BaseArrayType> {
     fetchFunction: (...params: P) => Promise<T>;
@@ -19,15 +19,14 @@ export type UseFetchStateParams<T, P extends BaseArrayType> =
     | UseFetchStateParamsDelayed<T, P>
     | UseFetchStateParamsImmediate<T, P>;
 
-export interface UseFetchState<T, P extends BaseArrayType> extends FetchState<T> {
-    execute: (...params: P) => Promise<void>;
-}
+export type FetchFunction<P extends BaseArrayType = []> = (...params: P) => Promise<void>;
 
-export interface FetchState<T> {
-    value?: T;
-    isLoading: boolean;
-    error?: string;
-}
+export type UseFetchState<T, P extends BaseArrayType> = [
+    T | undefined,
+    boolean,
+    string | undefined,
+    FetchFunction<P>
+];
 
 export function useFetchState<T, P extends BaseArrayType>({
     fetchFunction,
@@ -72,5 +71,5 @@ export function useFetchState<T, P extends BaseArrayType>({
         }
     }, [execute, immediate, params, prevParams]);
 
-    return { execute, value, isLoading, error };
+    return [value, isLoading, error, execute];
 }

--- a/client/src/hooks/useSettings.tsx
+++ b/client/src/hooks/useSettings.tsx
@@ -32,7 +32,7 @@ const SettingsContext = React.createContext<ContextType>({
 
 export function SettingsProvider({ children }: RequireChildrenProp): JSX.Element {
     const { userData } = useLogin();
-    const { value, isLoading, execute } = useFetchState({ fetchFunction: getSettings });
+    const [value, isLoading, , execute] = useFetchState({ fetchFunction: getSettings });
     const updateSettings = useCallback(async () => {
         if (!!userData) {
             await execute();

--- a/client/src/pages/AppBar.tsx
+++ b/client/src/pages/AppBar.tsx
@@ -92,9 +92,7 @@ function getTitleFromPath(path: string | undefined): string {
 
 function useTitleFromRoute(): string {
     const match = useRouteMatch([...TITLE_TEXTS.keys()]);
-    const title = useMemo(() => getTitleFromPath(match?.path), [match]);
-
-    return title;
+    return useMemo(() => getTitleFromPath(match?.path), [match]);
 }
 
 function AppBar({ onMenuButtonClicked }: Props): JSX.Element {
@@ -111,7 +109,7 @@ function AppBar({ onMenuButtonClicked }: Props): JSX.Element {
 
     const [backupAnchor, setBackupAnchor] = useState<HTMLElement | undefined>(undefined);
     const [creatingXLSX, setCreatingXLSX] = useState<CreatingState>({});
-    const { value: handbookUrl, error: handbookUrlError } = useFetchState({
+    const [handbookUrl, , handbookUrlError] = useFetchState({
         fetchFunction: getHandbookUrl,
         immediate: true,
         params: [],

--- a/client/src/pages/dashboard/Dashboard.tsx
+++ b/client/src/pages/dashboard/Dashboard.tsx
@@ -50,20 +50,15 @@ async function getTutorialSummariesForUser(
 function Dashboard(): JSX.Element {
     const { userData } = useLogin();
 
-    const {
-        value: tutorialsWithScheinCriteriaSummaries,
-        isLoading: isLoadingTutorialSummaries,
-    } = useFetchState({
+    const [tutorialsWithScheinCriteriaSummaries, isLoadingTutorialSummaries] = useFetchState({
         fetchFunction: getTutorialSummariesForUser,
         immediate: true,
         params: [userData],
     });
 
-    const {
-        execute: fetchSummaries,
-        isLoading: isLoadingAdminGraph,
-        value: summaries,
-    } = useFetchState({ fetchFunction: getScheinCriteriaSummaryOfAllStudentsWithTutorialSlots });
+    const [summaries, isLoadingAdminGraph, , fetchSummaries] = useFetchState({
+        fetchFunction: getScheinCriteriaSummaryOfAllStudentsWithTutorialSlots,
+    });
 
     return (
         <div>

--- a/client/src/pages/hand-ins/short-test-management/ShortTestManagement.tsx
+++ b/client/src/pages/hand-ins/short-test-management/ShortTestManagement.tsx
@@ -39,7 +39,7 @@ function ShortTestManagement(): JSX.Element {
     const dialog = useDialog();
     const { enqueueSnackbar } = useSnackbar();
 
-    const { isLoading, value } = useFetchState({
+    const [value, isLoading] = useFetchState({
         fetchFunction: getAllShortTests,
         immediate: true,
         params: [],

--- a/client/src/pages/import-short-tests/components/adjust-generated-short-test/AdjustGeneratedShortTest.tsx
+++ b/client/src/pages/import-short-tests/components/adjust-generated-short-test/AdjustGeneratedShortTest.tsx
@@ -101,7 +101,7 @@ function AdjustGeneratedShortTest(): JSX.Element {
     } = useImportCSVContext<ShortTestColumns, string>();
     const { getMapping, shortTest } = useIliasMappingContext();
     const [isImporting, setImporting] = useState(false);
-    const { isLoading, value } = useFetchState({
+    const [value, isLoading] = useFetchState({
         fetchFunction: generateInitialValues,
         immediate: true,
         params: [shortTest, mappedColumns, csvData.rows],

--- a/client/src/pages/import-short-tests/components/map-students-ilias-names/IliasMapping.context.tsx
+++ b/client/src/pages/import-short-tests/components/map-students-ilias-names/IliasMapping.context.tsx
@@ -3,14 +3,14 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import { useImportCSVContext } from '../../../../components/import-csv/ImportCSV.context';
 import { getShortTest } from '../../../../hooks/fetching/ShortTests';
 import { getAllStudents } from '../../../../hooks/fetching/Student';
-import { useFetchState, UseFetchState } from '../../../../hooks/useFetchState';
+import { FetchFunction, useFetchState } from '../../../../hooks/useFetchState';
 import { ShortTest } from '../../../../model/ShortTest';
 import { Student } from '../../../../model/Student';
 import { RequireChildrenProp } from '../../../../typings/RequireChildrenProp';
 import { throwContextNotInitialized } from '../../../../util/throwFunctions';
 import { ShortTestColumns } from '../ImportShortTests';
 
-interface ContextValue extends UseFetchState<Student[], []> {
+interface ContextValue {
     iliasNameMapping: Map<string, Student>;
     iliasNamesWithoutStudent: string[];
     studentsWithoutResult: Student[];
@@ -19,6 +19,11 @@ interface ContextValue extends UseFetchState<Student[], []> {
     addMapping: (iliasName: string, student: Student) => void;
     getMapping: (iliasName: string) => Student | undefined;
     removeMapping: (iliasName: string) => void;
+
+    isLoading: boolean;
+    error?: string;
+    value: Student[];
+    execute: FetchFunction;
 }
 
 const IliasMappingContext = React.createContext<ContextValue>({
@@ -48,12 +53,12 @@ function IliasMappingProvider({ children, shortTestId }: Props): JSX.Element {
         csvData,
         mapColumnsHelpers: { mappedColumns },
     } = useImportCSVContext<ShortTestColumns, string>();
-    const { isLoading: isLoadingStudents, error, value: students, execute } = useFetchState({
+    const [students, isLoadingStudents, error, execute] = useFetchState({
         fetchFunction: getAllStudents,
         immediate: true,
         params: [],
     });
-    const { isLoading: isLoadingShortTest, value: shortTest } = useFetchState({
+    const [shortTest, isLoadingShortTest] = useFetchState({
         fetchFunction: async () => {
             if (!shortTestId) {
                 return undefined;

--- a/client/src/pages/import-users/adjust-data-form/AdjustImportedUserDataForm.tsx
+++ b/client/src/pages/import-users/adjust-data-form/AdjustImportedUserDataForm.tsx
@@ -109,7 +109,7 @@ function AdjustImportedUserDataForm(): JSX.Element {
         mapColumnsHelpers: { mappedColumns },
     } = useImportCSVContext<UserColumns, string>();
     const { enqueueSnackbar, enqueueSnackbarWithList } = useCustomSnackbar();
-    const { isLoading, value: tutorials } = useFetchState({
+    const [tutorials, isLoading] = useFetchState({
         fetchFunction: getAllTutorials,
         immediate: true,
         params: [],

--- a/client/src/pages/student-info/StudentInfo.tsx
+++ b/client/src/pages/student-info/StudentInfo.tsx
@@ -53,17 +53,17 @@ function StudentInfo(): JSX.Element {
     const [tutorialOfStudent, setTutorialOfStudent] = useState<Tutorial>();
     const [scheinStatus, setScheinStatus] = useState<ScheinCriteriaSummary>();
 
-    const { value: sheets = [] } = useFetchState({
+    const [sheets = []] = useFetchState({
         fetchFunction: getAllSheets,
         immediate: true,
         params: [],
     });
-    const { value: exams = [] } = useFetchState({
+    const [exams = []] = useFetchState({
         fetchFunction: getAllScheinExams,
         immediate: true,
         params: [],
     });
-    const { value: shortTests = [] } = useFetchState({
+    const [shortTests = []] = useFetchState({
         fetchFunction: getAllShortTests,
         immediate: true,
         params: [],

--- a/client/src/pages/studentmanagement/student-list/StudentList.helpers.ts
+++ b/client/src/pages/studentmanagement/student-list/StudentList.helpers.ts
@@ -62,7 +62,7 @@ export function useStudentsForStudentList({
     const [students, setStudents] = useState<Student[]>([]);
     const { enqueueSnackbar } = useSnackbar();
 
-    const { value: summaries = {}, isLoading: isLoadingSummaries } = useFetchState({
+    const [summaries = {}, isLoadingSummaries] = useFetchState({
         fetchFunction: async (tutorialId: string) => {
             const fetchedSummaries = await (tutorialId
                 ? getScheinCriteriaSummariesOfAllStudentsOfTutorial(tutorialId)
@@ -77,7 +77,7 @@ export function useStudentsForStudentList({
         immediate: true,
         params: [tutorialId ?? ''],
     });
-    const { value: teams, execute: fetchTeams } = useFetchState({
+    const [teams, , , fetchTeams] = useFetchState({
         fetchFunction: tutorialId ? getTeamsOfTutorial : async () => undefined,
         immediate: true,
         params: [tutorialId ?? ''],

--- a/client/src/pages/studentmanagement/student-list/components/TutorialChangeForm.tsx
+++ b/client/src/pages/studentmanagement/student-list/components/TutorialChangeForm.tsx
@@ -45,7 +45,7 @@ function TutorialChangeForm({
 }: Props): JSX.Element {
     const classes = useStyles();
 
-    const { value: allTutorials, isLoading } = useFetchState({
+    const [allTutorials, isLoading] = useFetchState({
         fetchFunction: getAllTutorials,
         immediate: true,
         params: [],

--- a/client/src/pages/tutorialmanagement/TutorialManagement.context.tsx
+++ b/client/src/pages/tutorialmanagement/TutorialManagement.context.tsx
@@ -46,7 +46,7 @@ export function useTutorialManagementContext(): TutorialManagementContextType {
 
 function TutorialManagementContextProvider({ children }: Props): JSX.Element {
     const { enqueueSnackbarWithList } = useCustomSnackbar();
-    const [sorter, setSorter] = useState<TutorialSorter>(SORTERS.alphabetical);
+    const [sorter, setSorter] = useState<TutorialSorter>(SORTERS.date);
 
     const [tutorials = [], isLoadingTutorials, errorTutorials, fetchTutorials] = useFetchState({
         fetchFunction: getAllTutorials,

--- a/client/src/pages/tutorialmanagement/TutorialManagement.context.tsx
+++ b/client/src/pages/tutorialmanagement/TutorialManagement.context.tsx
@@ -1,0 +1,123 @@
+import React, { ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { Role } from 'shared/model/Role';
+import { IUser } from 'shared/model/User';
+import { getAllTutorials } from '../../hooks/fetching/Tutorial';
+import { getUsersWithRole } from '../../hooks/fetching/User';
+import { useCustomSnackbar } from '../../hooks/snackbar/useCustomSnackbar';
+import { useFetchState } from '../../hooks/useFetchState';
+import { Tutorial } from '../../model/Tutorial';
+import { throwContextNotInitialized } from '../../util/throwFunctions';
+
+interface Props {
+    children?: ReactNode;
+}
+
+interface FetchErrors {
+    tutorials?: string;
+    tutors?: string;
+    correctors?: string;
+}
+
+export interface TutorialManagementContextType {
+    tutorials: Tutorial[];
+    tutors: IUser[];
+    correctors: IUser[];
+    isLoading: boolean;
+    setTutorials: (tutorials: Tutorial[]) => void;
+    error?: FetchErrors;
+}
+
+const Context = React.createContext<TutorialManagementContextType>({
+    tutorials: [],
+    tutors: [],
+    correctors: [],
+    isLoading: false,
+    error: undefined,
+    setTutorials: throwContextNotInitialized('TutorialManagementContext'),
+});
+
+export function useTutorialManagementContext(): TutorialManagementContextType {
+    const value = useContext(Context);
+    return { ...value };
+}
+
+function TutorialManagementContextProvider({ children }: Props): JSX.Element {
+    const { enqueueSnackbarWithList } = useCustomSnackbar();
+
+    const [tutorials = [], isLoadingTutorials, errorTutorials] = useFetchState({
+        fetchFunction: getAllTutorials,
+        immediate: true,
+        params: [],
+    });
+    const [tutors = [], isLoadingTutors, errorTutors] = useFetchState({
+        fetchFunction: getUsersWithRole,
+        immediate: true,
+        params: [Role.TUTOR],
+    });
+    const [correctors = [], isLoadingCorrectors, errorCorrectors] = useFetchState({
+        fetchFunction: getUsersWithRole,
+        immediate: true,
+        params: [Role.CORRECTOR],
+    });
+
+    const [sortedTutorials, setSortedTutorials] = useState<Tutorial[]>([]);
+    const isLoading = isLoadingTutorials || isLoadingTutors || isLoadingCorrectors;
+    const error = useMemo<FetchErrors | undefined>(() => {
+        if (!errorTutorials && !errorTutors && !errorCorrectors) {
+            return undefined;
+        }
+
+        return { tutors: errorTutors, tutorials: errorTutorials, correctors: errorCorrectors };
+    }, [errorTutors, errorTutorials, errorCorrectors]);
+
+    const setTutorials = useCallback((tutorials: Tutorial[]) => {
+        // TODO: Add sorting / filter support
+        setSortedTutorials(tutorials);
+    }, []);
+
+    useEffect(() => {
+        setTutorials(tutorials);
+    }, [tutorials, setTutorials]);
+
+    useEffect(() => {
+        const items: string[] = [];
+
+        if (error?.tutorials) {
+            items.push(error.tutorials);
+        }
+
+        if (error?.tutors) {
+            items.push(error.tutors);
+        }
+
+        if (error?.correctors) {
+            items.push(error.correctors);
+        }
+
+        if (items.length > 0) {
+            enqueueSnackbarWithList({
+                title: 'Fehler beim Datenabruf',
+                textBeforeList: 'Beim Abrufen der Daten sind folgende Fehler aufgetreten:',
+                items: items,
+                variant: 'error',
+            });
+        }
+    }, [enqueueSnackbarWithList, error]);
+
+    return (
+        <Context.Provider
+            value={{
+                tutorials: sortedTutorials,
+                tutors,
+                correctors,
+                isLoading,
+                error,
+                setTutorials,
+            }}
+        >
+            {children}
+        </Context.Provider>
+    );
+}
+
+export default TutorialManagementContextProvider;

--- a/client/src/pages/tutorialmanagement/TutorialManagement.tsx
+++ b/client/src/pages/tutorialmanagement/TutorialManagement.tsx
@@ -15,7 +15,7 @@ import TutorialForm, {
 import LoadingSpinner from '../../components/loading/LoadingSpinner';
 import TableWithForm from '../../components/TableWithForm';
 import { useDialog } from '../../hooks/dialog-service/DialogService';
-import { createTutorial, deleteTutorial } from '../../hooks/fetching/Tutorial';
+import { createTutorial, deleteTutorial, editTutorial } from '../../hooks/fetching/Tutorial';
 import { useLoggedInUser } from '../../hooks/LoginService';
 import { useCustomSnackbar } from '../../hooks/snackbar/useCustomSnackbar';
 import { Tutorial } from '../../model/Tutorial';
@@ -105,6 +105,7 @@ function TutorialManagementContent(): JSX.Element {
     const handleEditTutorialSubmit: (tutorial: HasId) => TutorialFormSubmitCallback = useCallback(
         (tutorial) => async (values, { setSubmitting }) => {
             try {
+                await editTutorial(tutorial.id, generateCreateTutorialDTO(values));
                 await fetchTutorials();
                 enqueueSnackbar('Tutorium erfolgreich geändert.', { variant: 'success' });
                 dialog.hide();

--- a/client/src/pages/tutorialmanagement/TutorialManagement.tsx
+++ b/client/src/pages/tutorialmanagement/TutorialManagement.tsx
@@ -2,13 +2,10 @@ import { Button } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { DateTime } from 'luxon';
 import { AutoFix as GenerateIcon } from 'mdi-material-ui';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { HasId } from 'shared/model/Common';
-import { Role } from 'shared/model/Role';
 import { ITutorialDTO } from 'shared/model/Tutorial';
-import { IUser } from 'shared/model/User';
 import { getNameOfEntity } from 'shared/util/helpers';
 import TutorialForm, {
     getInitialTutorialFormValues,
@@ -18,19 +15,17 @@ import TutorialForm, {
 import LoadingSpinner from '../../components/loading/LoadingSpinner';
 import TableWithForm from '../../components/TableWithForm';
 import { useDialog } from '../../hooks/dialog-service/DialogService';
-import {
-    createTutorial,
-    deleteTutorial,
-    editTutorial,
-    getAllTutorials,
-} from '../../hooks/fetching/Tutorial';
-import { getUsersWithRole } from '../../hooks/fetching/User';
+import { createTutorial, deleteTutorial, editTutorial } from '../../hooks/fetching/Tutorial';
 import { useLoggedInUser } from '../../hooks/LoginService';
+import { useCustomSnackbar } from '../../hooks/snackbar/useCustomSnackbar';
 import { Tutorial } from '../../model/Tutorial';
 import { ROUTES } from '../../routes/Routing.routes';
 import { compareDateTimes } from '../../util/helperFunctions';
 import { useLogger } from '../../util/Logger';
 import TutorialTableRow from './components/TutorialTableRow';
+import TutorialManagementContextProvider, {
+    useTutorialManagementContext,
+} from './TutorialManagement.context';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -56,46 +51,32 @@ function generateCreateTutorialDTO({
 
     const dates: string[] = selectedDates
         .map((date) => DateTime.fromISO(date))
-        .map((date) => date.toISODate() ?? 'DATE_NOTE_PARSEABLE');
+        .map((date) => date.toISODate() ?? 'DATE_NOT_PARSABLE');
 
     return {
         slot,
         tutorId: tutor,
         dates,
-        startTime: startTime.toISOTime() ?? 'DATE_NOTE_PARSEABLE',
-        endTime: endTime.toISOTime() ?? 'DATE_NOTE_PARSEABLE',
+        startTime: startTime.toISOTime() ?? 'DATE_NOT_PARSABLE',
+        endTime: endTime.toISOTime() ?? 'DATE_NOT_PARSABLE',
         correctorIds: correctors,
     };
 }
 
-function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element {
+function TutorialManagementContent(): JSX.Element {
     const classes = useStyles();
     const dialog = useDialog();
     const user = useLoggedInUser();
+    const { enqueueSnackbar } = useCustomSnackbar();
     const logger = useLogger('TutorialManagement');
 
-    const [isLoading, setIsLoading] = useState(false);
-    const [tutorials, setTutorials] = useState<Tutorial[]>([]);
-    const [tutors, setTutors] = useState<IUser[]>([]);
-    const [correctors, setCorrectors] = useState<IUser[]>([]);
-
-    useEffect(() => {
-        setIsLoading(true);
-        Promise.all([
-            getUsersWithRole(Role.TUTOR),
-            getUsersWithRole(Role.CORRECTOR),
-            getAllTutorials(),
-        ])
-            .then(([tutorsResponse, correctorsResponse, tutorialResponse]) => {
-                setTutors(tutorsResponse || []);
-                setCorrectors(correctorsResponse || []);
-                setTutorials(tutorialResponse || []);
-                setIsLoading(false);
-            })
-            .catch(() => {
-                enqueueSnackbar('Daten konnten nicht abgerufen werden.', { variant: 'error' });
-            });
-    }, [enqueueSnackbar]);
+    const {
+        tutorials,
+        tutors,
+        correctors,
+        isLoading,
+        setTutorials,
+    } = useTutorialManagementContext();
 
     const handleCreateTutorial: TutorialFormSubmitCallback = async (
         values,
@@ -248,4 +229,12 @@ function TutorialManagement({ enqueueSnackbar }: WithSnackbarProps): JSX.Element
     );
 }
 
-export default withSnackbar(TutorialManagement);
+function TutorialManagement(): JSX.Element {
+    return (
+        <TutorialManagementContextProvider>
+            <TutorialManagementContent />
+        </TutorialManagementContextProvider>
+    );
+}
+
+export default TutorialManagement;

--- a/client/src/pages/tutorialmanagement/sorters/Sorters.ts
+++ b/client/src/pages/tutorialmanagement/sorters/Sorters.ts
@@ -1,0 +1,43 @@
+import { Tutorial } from '../../../model/Tutorial';
+
+export abstract class TutorialSorter {
+    abstract sort(tutorials: Tutorial[]): Tutorial[];
+}
+
+export class AlphabeticTutorialSorter extends TutorialSorter {
+    sort(tutorials: Tutorial[]): Tutorial[] {
+        const sortedTutorials = [...tutorials];
+        return sortedTutorials.sort((a, b) =>
+            a.toDisplayString().localeCompare(b.toDisplayString())
+        );
+    }
+}
+
+export class DateTutorialSorter extends TutorialSorter {
+    sort(tutorials: Tutorial[]): Tutorial[] {
+        return [...tutorials].sort((a, b) => {
+            const dateA = a.dates[0];
+            const dateB = b.dates[0];
+
+            if (!dateA && !dateB) {
+                return 0;
+            } else if (!dateA) {
+                return -1;
+            } else if (!dateB) {
+                return 1;
+            } else {
+                return dateA.diff(dateB, 'days').days;
+            }
+        });
+    }
+}
+
+export type SupportedSorters = 'alphabetical' | 'date';
+type Sorters = {
+    readonly [K in SupportedSorters]: TutorialSorter;
+};
+
+export const SORTERS: Sorters = {
+    alphabetical: new AlphabeticTutorialSorter(),
+    date: new DateTutorialSorter(),
+};

--- a/client/src/pages/tutorialmanagement/sorters/Sorters.ts
+++ b/client/src/pages/tutorialmanagement/sorters/Sorters.ts
@@ -4,15 +4,6 @@ export abstract class TutorialSorter {
     abstract sort(tutorials: Tutorial[]): Tutorial[];
 }
 
-export class AlphabeticTutorialSorter extends TutorialSorter {
-    sort(tutorials: Tutorial[]): Tutorial[] {
-        const sortedTutorials = [...tutorials];
-        return sortedTutorials.sort((a, b) =>
-            a.toDisplayString().localeCompare(b.toDisplayString())
-        );
-    }
-}
-
 export class DateTutorialSorter extends TutorialSorter {
     sort(tutorials: Tutorial[]): Tutorial[] {
         return [...tutorials].sort((a, b) => {
@@ -26,18 +17,18 @@ export class DateTutorialSorter extends TutorialSorter {
             } else if (!dateB) {
                 return 1;
             } else {
-                return dateA.diff(dateB, 'days').days;
+                const diff = dateA.diff(dateB, 'days').days;
+                return diff === 0 ? a.toDisplayString().localeCompare(b.toDisplayString()) : diff;
             }
         });
     }
 }
 
-export type SupportedSorters = 'alphabetical' | 'date';
+export type SupportedSorters = 'date';
 type Sorters = {
     readonly [K in SupportedSorters]: TutorialSorter;
 };
 
 export const SORTERS: Sorters = {
-    alphabetical: new AlphabeticTutorialSorter(),
     date: new DateTutorialSorter(),
 };

--- a/client/src/pages/usermanagement/UserManagement.tsx
+++ b/client/src/pages/usermanagement/UserManagement.tsx
@@ -98,16 +98,16 @@ function UserManagement(): JSX.Element {
     const { isMailingActive } = useSettings();
     const { enqueueSnackbar, closeSnackbar, enqueueSnackbarWithList } = useCustomSnackbar();
 
-    const { value: users = [], isLoading: isLoadingUsers, execute: fetchUsers } = useFetchState({
+    const [users = [], isLoadingUsers, , fetchUsers] = useFetchState({
         fetchFunction: getUsers,
         immediate: true,
         params: [],
     });
-    const {
-        value: tutorials = [],
-        isLoading: isLoadingTutorials,
-        execute: fetchTutorials,
-    } = useFetchState({ fetchFunction: getAllTutorials, immediate: true, params: [] });
+    const [tutorials = [], isLoadingTutorials, , fetchTutorials] = useFetchState({
+        fetchFunction: getAllTutorials,
+        immediate: true,
+        params: [],
+    });
 
     const [isLoadingInitially, setLoadingInitially] = useState(true);
     const [isSendingCredentials, setSendingCredentials] = useState(false);

--- a/server/src/shared/model/Tutorial.ts
+++ b/server/src/shared/model/Tutorial.ts
@@ -32,11 +32,6 @@ export interface ISubstituteDTO {
     dates: string[];
 }
 
-// export enum TutorialGenerationDataType {
-//   SINGLE = 'single',
-//   MULTIPLE = 'multiple',
-// }
-
 /**
  * Numerated weekdays. These follow the same numeration than the [weekdays in luxon](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-get-weekday).
  */
@@ -68,15 +63,3 @@ export interface IExcludedDate {
     date?: string;
     interval?: string;
 }
-
-// export type IExcludedDate = IExcludedSingleDate | IExcludedMultipleDate;
-
-// export interface IExcludedSingleDate {
-//   type: TutorialGenerationDataType.SINGLE;
-//   date: string;
-// }
-
-// export interface IExcludedMultipleDate {
-//   type: TutorialGenerationDataType.MULTIPLE;
-//   interval: string;
-// }


### PR DESCRIPTION
# :ticket: Description

Add sorting options to the tutorials management page.

<!-- Describe this PR -->

# :lock: Closes

- Closes #870 
<!-- Which issue(s) is (are) being closed by the PR? -->
