### PR TITLE
Fix passed state of shorttest not being calculation correctly.

### DIFF
--- a/server/src/module/scheincriteria/container/criterias/ShortTestCriteria.ts
+++ b/server/src/module/scheincriteria/container/criterias/ShortTestCriteria.ts
@@ -75,7 +75,7 @@ export class ShortTestCriteria extends PossiblePercentageCriteria {
 
                 let state = PassedState.NOT_PASSED;
                 if (this.isPercentagePerTest) {
-                    if (achieved / total >= this.valuePerTestNeeded) {
+                    if (shortTest.hasPassed(student)) {
                         state = PassedState.PASSED;
                     }
                 } else {


### PR DESCRIPTION
# :ticket: Description

Fixes that the short test calculation does not use the percentage set in the test.
<!-- Describe this PR -->

