### PR TITLE
Bugfix/change db to sql

### DIFF
--- a/server/src/database/sql-database.module.ts
+++ b/server/src/database/sql-database.module.ts
@@ -1,6 +1,6 @@
 import { MikroORM } from '@mikro-orm/core';
 import { ISchemaGenerator } from '@mikro-orm/core/typings';
-import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { MikroOrmModule, MikroOrmModuleSyncOptions } from '@mikro-orm/nestjs';
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 import { DynamicModule, Logger, Module, OnApplicationShutdown, OnModuleInit } from '@nestjs/common';
 import { StartUpException } from '../exceptions/StartUpException';
@@ -12,7 +12,7 @@ function getEntityDirectory(): string {
     return isProduction() ? './database/entities' : './dist/database/entities';
 }
 
-export function loadDatabaseModule(): DynamicModule {
+export function loadDatabaseModule(additionalOptions: MikroOrmModuleSyncOptions = {}): DynamicModule {
     return MikroOrmModule.forRoot({
         metadataProvider: TsMorphMetadataProvider,
         baseDir: process.cwd(),
@@ -22,6 +22,7 @@ export function loadDatabaseModule(): DynamicModule {
         type: 'mysql',
         debug: false,
         ...StaticSettings.getService().getDatabaseConnectionInformation(),
+        ...additionalOptions,
     });
 }
 

--- a/server/src/database/sql-database.module.ts
+++ b/server/src/database/sql-database.module.ts
@@ -12,7 +12,9 @@ function getEntityDirectory(): string {
     return isProduction() ? './database/entities' : './dist/database/entities';
 }
 
-export function loadDatabaseModule(additionalOptions: MikroOrmModuleSyncOptions = {}): DynamicModule {
+export function loadDatabaseModule(
+    additionalOptions: MikroOrmModuleSyncOptions = {}
+): DynamicModule {
     return MikroOrmModule.forRoot({
         metadataProvider: TsMorphMetadataProvider,
         baseDir: process.cwd(),

--- a/server/src/module/scheincriteria/scheincriteria.module.ts
+++ b/server/src/module/scheincriteria/scheincriteria.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Logger, Module, OnModuleInit } from '@nestjs/common';
-import { ScheincriteriaEntity } from 'database/entities/scheincriteria.entity';
+import { ScheincriteriaEntity } from '../../database/entities/scheincriteria.entity';
 import { ScheinexamModule } from '../scheinexam/scheinexam.module';
 import { SheetModule } from '../sheet/sheet.module';
 import { ShortTestModule } from '../short-test/short-test.module';

--- a/server/src/module/scheincriteria/scheincriteria.module.ts
+++ b/server/src/module/scheincriteria/scheincriteria.module.ts
@@ -1,4 +1,6 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Logger, Module, OnModuleInit } from '@nestjs/common';
+import { ScheincriteriaEntity } from 'database/entities/scheincriteria.entity';
 import { ScheinexamModule } from '../scheinexam/scheinexam.module';
 import { SheetModule } from '../sheet/sheet.module';
 import { ShortTestModule } from '../short-test/short-test.module';
@@ -19,7 +21,14 @@ import { ScheincriteriaService } from './scheincriteria.service';
 export type ScheincriteriaConstructor = new (...args: any[]) => Scheincriteria;
 
 @Module({
-    imports: [StudentModule, SheetModule, ScheinexamModule, TutorialModule, ShortTestModule],
+    imports: [
+        StudentModule,
+        SheetModule,
+        ScheinexamModule,
+        TutorialModule,
+        ShortTestModule,
+        MikroOrmModule.forFeature([ScheincriteriaEntity]),
+    ],
     providers: [ScheincriteriaService],
     controllers: [ScheincriteriaController],
     exports: [ScheincriteriaService],

--- a/server/src/module/scheincriteria/scheincriteria.service.ts
+++ b/server/src/module/scheincriteria/scheincriteria.service.ts
@@ -1,5 +1,4 @@
 import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { FormDataResponse } from 'shared/model/FormTypes';
 import {
@@ -24,6 +23,7 @@ import { Scheincriteria } from './container/Scheincriteria';
 import { ScheincriteriaContainer } from './container/scheincriteria.container';
 import { ScheinCriteriaDTO } from './scheincriteria.dto';
 import { GradingService, StudentAndGradings } from '../student/grading.service';
+import { InjectRepository } from '@mikro-orm/nestjs';
 
 interface CalculationParams {
     criterias: ScheincriteriaEntity[];
@@ -50,7 +50,6 @@ interface GetRequiredDocsParams {
 export class ScheincriteriaService
     implements CRUDService<IScheinCriteria, ScheinCriteriaDTO, ScheincriteriaEntity>
 {
-    private readonly repository: EntityRepository<ScheincriteriaEntity>;
 
     constructor(
         private readonly studentService: StudentService,
@@ -59,10 +58,9 @@ export class ScheincriteriaService
         private readonly tutorialService: TutorialService,
         private readonly shortTestService: ShortTestService,
         private readonly gradingService: GradingService,
-        entityManager: EntityManager
-    ) {
-        this.repository = entityManager.fork().getRepository(ScheincriteriaEntity);
-    }
+        @InjectRepository(ScheincriteriaEntity)
+        private readonly repository: EntityRepository<ScheincriteriaEntity>
+    ) { }
 
     /**
      * @returns All scheincriterias saved in the database.

--- a/server/src/module/scheincriteria/scheincriteria.service.ts
+++ b/server/src/module/scheincriteria/scheincriteria.service.ts
@@ -50,7 +50,6 @@ interface GetRequiredDocsParams {
 export class ScheincriteriaService
     implements CRUDService<IScheinCriteria, ScheinCriteriaDTO, ScheincriteriaEntity>
 {
-
     constructor(
         private readonly studentService: StudentService,
         private readonly sheetService: SheetService,
@@ -60,7 +59,7 @@ export class ScheincriteriaService
         private readonly gradingService: GradingService,
         @InjectRepository(ScheincriteriaEntity)
         private readonly repository: EntityRepository<ScheincriteriaEntity>
-    ) { }
+    ) {}
 
     /**
      * @returns All scheincriterias saved in the database.

--- a/server/src/module/scheinexam/scheinexam.module.ts
+++ b/server/src/module/scheinexam/scheinexam.module.ts
@@ -1,8 +1,11 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
+import { Scheinexam } from 'database/entities/scheinexam.entity';
 import { ScheinexamController } from './scheinexam.controller';
 import { ScheinexamService } from './scheinexam.service';
 
 @Module({
+    imports: [MikroOrmModule.forFeature([Scheinexam])],
     controllers: [ScheinexamController],
     providers: [ScheinexamService],
     exports: [ScheinexamService],

--- a/server/src/module/scheinexam/scheinexam.module.ts
+++ b/server/src/module/scheinexam/scheinexam.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
-import { Scheinexam } from 'database/entities/scheinexam.entity';
+import { Scheinexam } from '../../database/entities/scheinexam.entity';
 import { ScheinexamController } from './scheinexam.controller';
 import { ScheinexamService } from './scheinexam.service';
 

--- a/server/src/module/scheinexam/scheinexam.service.ts
+++ b/server/src/module/scheinexam/scheinexam.service.ts
@@ -8,11 +8,10 @@ import { ScheinexamDTO } from './scheinexam.dto';
 
 @Injectable()
 export class ScheinexamService implements CRUDService<IScheinExam, ScheinexamDTO, Scheinexam> {
-
     constructor(
         @InjectRepository(Scheinexam)
         private readonly repository: EntityRepository<Scheinexam>
-    ) { }
+    ) {}
 
     /**
      * @returns All scheinexams saved in the database.

--- a/server/src/module/scheinexam/scheinexam.service.ts
+++ b/server/src/module/scheinexam/scheinexam.service.ts
@@ -1,5 +1,5 @@
 import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { IScheinExam } from 'shared/model/Scheinexam';
 import { Scheinexam } from '../../database/entities/scheinexam.entity';
@@ -8,11 +8,11 @@ import { ScheinexamDTO } from './scheinexam.dto';
 
 @Injectable()
 export class ScheinexamService implements CRUDService<IScheinExam, ScheinexamDTO, Scheinexam> {
-    private readonly repository: EntityRepository<Scheinexam>;
 
-    constructor(entityManager: EntityManager) {
-        this.repository = entityManager.fork().getRepository(Scheinexam);
-    }
+    constructor(
+        @InjectRepository(Scheinexam)
+        private readonly repository: EntityRepository<Scheinexam>
+    ) { }
 
     /**
      * @returns All scheinexams saved in the database.

--- a/server/src/module/session/session.module.ts
+++ b/server/src/module/session/session.module.ts
@@ -1,7 +1,10 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
+import { SessionEntity } from 'database/entities/session.entity';
 import { SessionService } from './session.service';
 
 @Module({
+    imports: [MikroOrmModule.forFeature([SessionEntity])],
     providers: [SessionService],
     exports: [SessionService],
 })

--- a/server/src/module/session/session.module.ts
+++ b/server/src/module/session/session.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
-import { SessionEntity } from 'database/entities/session.entity';
+import { SessionEntity } from '../../database/entities/session.entity';
 import { SessionService } from './session.service';
 
 @Module({

--- a/server/src/module/session/session.service.ts
+++ b/server/src/module/session/session.service.ts
@@ -15,7 +15,7 @@ export class SessionService implements ISessionService {
         private readonly orm: MikroORM,
         @InjectRepository(SessionEntity)
         private readonly repository: EntityRepository<SessionEntity>
-    ) { }
+    ) {}
 
     @UseRequestContext()
     async setSession(sid: string, sessionData: SessionData): Promise<void> {

--- a/server/src/module/session/session.service.ts
+++ b/server/src/module/session/session.service.ts
@@ -1,5 +1,5 @@
-import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
+import { EntityRepository, MikroORM, UseRequestContext } from '@mikro-orm/core';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable, Logger } from '@nestjs/common';
 import { SessionEntity } from '../../database/entities/session.entity';
 import {
@@ -10,12 +10,14 @@ import {
 @Injectable()
 export class SessionService implements ISessionService {
     private readonly logger = new Logger(SessionService.name);
-    private readonly repository: EntityRepository<SessionEntity>;
 
-    constructor(entityManager: EntityManager) {
-        this.repository = entityManager.fork().getRepository(SessionEntity);
-    }
+    constructor(
+        private readonly orm: MikroORM,
+        @InjectRepository(SessionEntity)
+        private readonly repository: EntityRepository<SessionEntity>
+    ) { }
 
+    @UseRequestContext()
     async setSession(sid: string, sessionData: SessionData): Promise<void> {
         this.logger.log(`SET session for ID ${sid}`);
         const session = (await this.findSession(sid)) ?? new SessionEntity(sid, sessionData);
@@ -24,12 +26,14 @@ export class SessionService implements ISessionService {
         await this.repository.persistAndFlush(session);
     }
 
+    @UseRequestContext()
     async getSession(sid: string): Promise<SessionData | null> {
         this.logger.log(`GET session for ID ${sid}`);
         const session = await this.findSession(sid);
         return session?.sessionData ?? null;
     }
 
+    @UseRequestContext()
     async destroySession(sid: string): Promise<void> {
         this.logger.log(`DESTROY session with ID ${sid}`);
         const session = await this.findSession(sid);

--- a/server/src/module/settings/settings.module.ts
+++ b/server/src/module/settings/settings.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Global, Module } from '@nestjs/common';
-import { Setting } from 'database/entities/settings.entity';
+import { Setting } from '../../database/entities/settings.entity';
 import { SettingsController } from './settings.controller';
 import { SettingsService } from './settings.service';
 

--- a/server/src/module/settings/settings.module.ts
+++ b/server/src/module/settings/settings.module.ts
@@ -1,9 +1,12 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Global, Module } from '@nestjs/common';
+import { Setting } from 'database/entities/settings.entity';
 import { SettingsController } from './settings.controller';
 import { SettingsService } from './settings.service';
 
 @Global()
 @Module({
+    imports: [MikroOrmModule.forFeature([Setting])],
     providers: [SettingsService],
     exports: [SettingsService],
     controllers: [SettingsController],

--- a/server/src/module/settings/settings.service.ts
+++ b/server/src/module/settings/settings.service.ts
@@ -9,13 +9,12 @@ import { StaticSettings } from './settings.static';
 
 @Injectable()
 export class SettingsService extends StaticSettings implements OnApplicationBootstrap {
-
     constructor(
         private readonly orm: MikroORM,
         @InjectRepository(Setting)
-        private readonly repository: EntityRepository<Setting> 
-    ) { 
-        super()
+        private readonly repository: EntityRepository<Setting>
+    ) {
+        super();
     }
 
     /**

--- a/server/src/module/settings/settings.service.ts
+++ b/server/src/module/settings/settings.service.ts
@@ -1,5 +1,5 @@
-import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
+import { EntityRepository, MikroORM, UseRequestContext } from '@mikro-orm/core';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { IClientSettings, IMailingSettings } from 'shared/model/Settings';
 import { Setting } from '../../database/entities/settings.entity';
@@ -9,11 +9,13 @@ import { StaticSettings } from './settings.static';
 
 @Injectable()
 export class SettingsService extends StaticSettings implements OnApplicationBootstrap {
-    private readonly repository: EntityRepository<Setting>;
 
-    constructor(entityManager: EntityManager) {
-        super();
-        this.repository = entityManager.fork().getRepository(Setting);
+    constructor(
+        private readonly orm: MikroORM,
+        @InjectRepository(Setting)
+        private readonly repository: EntityRepository<Setting> 
+    ) { 
+        super()
     }
 
     /**
@@ -56,6 +58,7 @@ export class SettingsService extends StaticSettings implements OnApplicationBoot
      *
      * If there is ONE nothing is done.
      */
+    @UseRequestContext()
     async onApplicationBootstrap(): Promise<void> {
         const settings = await this.repository.findOne({
             id: Setting.SETTING_ID,

--- a/server/src/module/sheet/sheet.module.ts
+++ b/server/src/module/sheet/sheet.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
-import { Sheet } from 'database/entities/sheet.entity';
+import { Sheet } from '../../database/entities/sheet.entity';
 import { SheetController } from './sheet.controller';
 import { SheetService } from './sheet.service';
 

--- a/server/src/module/sheet/sheet.module.ts
+++ b/server/src/module/sheet/sheet.module.ts
@@ -1,8 +1,11 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
+import { Sheet } from 'database/entities/sheet.entity';
 import { SheetController } from './sheet.controller';
 import { SheetService } from './sheet.service';
 
 @Module({
+    imports: [MikroOrmModule.forFeature([Sheet])],
     controllers: [SheetController],
     providers: [SheetService],
     exports: [SheetService],

--- a/server/src/module/sheet/sheet.service.ts
+++ b/server/src/module/sheet/sheet.service.ts
@@ -9,11 +9,10 @@ import { SheetDTO } from './sheet.dto';
 
 @Injectable()
 export class SheetService implements CRUDService<ISheet, SheetDTO, Sheet> {
-
     constructor(
         @InjectRepository(Sheet)
         private readonly repository: EntityRepository<Sheet>
-    ) { }
+    ) {}
 
     /**
      * @returns All sheets saved in the database.

--- a/server/src/module/sheet/sheet.service.ts
+++ b/server/src/module/sheet/sheet.service.ts
@@ -1,5 +1,5 @@
 import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { ISheet } from 'shared/model/Sheet';
 import { Exercise } from '../../database/entities/ratedEntity.entity';
@@ -9,11 +9,11 @@ import { SheetDTO } from './sheet.dto';
 
 @Injectable()
 export class SheetService implements CRUDService<ISheet, SheetDTO, Sheet> {
-    private readonly repository: EntityRepository<Sheet>;
 
-    constructor(entityManager: EntityManager) {
-        this.repository = entityManager.fork().getRepository(Sheet);
-    }
+    constructor(
+        @InjectRepository(Sheet)
+        private readonly repository: EntityRepository<Sheet>
+    ) { }
 
     /**
      * @returns All sheets saved in the database.

--- a/server/src/module/short-test/short-test.module.ts
+++ b/server/src/module/short-test/short-test.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { ShortTestService } from './short-test.service';
 import { ShortTestController } from './short-test.controller';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
-import { ShortTest } from 'database/entities/shorttest.entity';
+import { ShortTest } from '../../database/entities/shorttest.entity';
 
 @Module({
     imports: [MikroOrmModule.forFeature([ShortTest])],

--- a/server/src/module/short-test/short-test.module.ts
+++ b/server/src/module/short-test/short-test.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ShortTestService } from './short-test.service';
 import { ShortTestController } from './short-test.controller';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { ShortTest } from 'database/entities/shorttest.entity';
 
 @Module({
+    imports: [MikroOrmModule.forFeature([ShortTest])],
     providers: [ShortTestService],
     exports: [ShortTestService],
     controllers: [ShortTestController],

--- a/server/src/module/short-test/short-test.service.ts
+++ b/server/src/module/short-test/short-test.service.ts
@@ -8,11 +8,10 @@ import { ShortTestDTO } from '../scheinexam/scheinexam.dto';
 
 @Injectable()
 export class ShortTestService implements CRUDService<IShortTest, ShortTestDTO, ShortTest> {
-
     constructor(
         @InjectRepository(ShortTest)
         private readonly repository: EntityRepository<ShortTest>
-    ) { }
+    ) {}
 
     async findAll(): Promise<ShortTest[]> {
         return this.repository.findAll();

--- a/server/src/module/short-test/short-test.service.ts
+++ b/server/src/module/short-test/short-test.service.ts
@@ -1,5 +1,5 @@
 import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { IShortTest } from 'shared/model/ShortTest';
 import { ShortTest } from '../../database/entities/shorttest.entity';
@@ -8,11 +8,11 @@ import { ShortTestDTO } from '../scheinexam/scheinexam.dto';
 
 @Injectable()
 export class ShortTestService implements CRUDService<IShortTest, ShortTestDTO, ShortTest> {
-    private readonly repository: EntityRepository<ShortTest>;
 
-    constructor(entityManager: EntityManager) {
-        this.repository = entityManager.fork().getRepository(ShortTest);
-    }
+    constructor(
+        @InjectRepository(ShortTest)
+        private readonly repository: EntityRepository<ShortTest>
+    ) { }
 
     async findAll(): Promise<ShortTest[]> {
         return this.repository.findAll();

--- a/server/src/module/student/grading.service.ts
+++ b/server/src/module/student/grading.service.ts
@@ -12,10 +12,10 @@ import { StudentService } from './student.service';
 import { GradingList, GradingListsForStudents } from '../../helpers/GradingList';
 import { Team } from '../../database/entities/team.entity';
 import { GradingResponseData } from 'shared/model/Gradings';
+import { InjectRepository } from '@mikro-orm/nestjs';
 
 @Injectable()
 export class GradingService {
-    private readonly repository: EntityRepository<Grading>;
 
     constructor(
         @Inject(forwardRef(() => StudentService))
@@ -23,10 +23,10 @@ export class GradingService {
         private readonly sheetService: SheetService,
         private readonly scheinexamService: ScheinexamService,
         private readonly shortTestService: ShortTestService,
-        private readonly entityManager: EntityManager
-    ) {
-        this.repository = entityManager.fork().getRepository(Grading);
-    }
+        private readonly entityManager: EntityManager,
+        @InjectRepository(Grading)
+        private readonly repository: EntityRepository<Grading>
+    ) { }
 
     /**
      * @param handInId ID of the hand-in to find the gradings for.

--- a/server/src/module/student/grading.service.ts
+++ b/server/src/module/student/grading.service.ts
@@ -137,7 +137,7 @@ export class GradingService {
             const handIn = await this.getHandInFromDTO(dto);
             await this.updateGradingOfStudent({ student, dto, handIn });
         }
-        await this.entityManager.flush()
+        await this.entityManager.flush();
     }
 
     /**

--- a/server/src/module/student/grading.service.ts
+++ b/server/src/module/student/grading.service.ts
@@ -75,6 +75,24 @@ export class GradingService {
     }
 
     /**
+     * @param studentIds IDs of the students to get the grading for.
+     * @param handInId ID of the hand-in to get the grading of.
+     *
+     * @returns Gradings which matche the parameters.
+     */
+    async findOfStudentsAndHandIn(
+        studentIds: string[],
+        handInId: string
+    ): Promise<Grading[]> {
+        const gradings = await this.repository.find(
+            { students: studentIds, handInId: handInId },
+            { populate: true }
+        );
+
+        return gradings;
+    }
+
+    /**
      * @param studentIds IDs of all students to get the gradings for.
      *
      * @returns The gradings of the students with the given IDs.
@@ -165,11 +183,12 @@ export class GradingService {
             const handIn = await this.getHandInFromDTO(dto);
             const students = team.getStudents();
             if (students.length > 0) {
-                const oldGrading = await this.findOfStudentAndHandIn(students[0].id, handIn.id);
-                if (oldGrading?.belongsToTeam === false) {
+                const oldGradings = await this.findOfStudentsAndHandIn(students.map((student) => student.id), handIn.id);
+                if (oldGradings.length > 1) {
                     // noinspection ExceptionCaughtLocallyJS
                     throw new BadRequestException('Students have different gradings.');
                 }
+                const oldGrading = oldGradings[0]
                 const newGrading =
                     !oldGrading || dto.createNewGrading ? new Grading({ handIn }) : oldGrading;
 

--- a/server/src/module/student/grading.service.ts
+++ b/server/src/module/student/grading.service.ts
@@ -16,7 +16,6 @@ import { InjectRepository } from '@mikro-orm/nestjs';
 
 @Injectable()
 export class GradingService {
-
     constructor(
         @Inject(forwardRef(() => StudentService))
         private readonly studentService: StudentService,
@@ -26,7 +25,7 @@ export class GradingService {
         private readonly entityManager: EntityManager,
         @InjectRepository(Grading)
         private readonly repository: EntityRepository<Grading>
-    ) { }
+    ) {}
 
     /**
      * @param handInId ID of the hand-in to find the gradings for.
@@ -165,13 +164,17 @@ export class GradingService {
             const handIn = await this.getHandInFromDTO(dto);
             const students = team.getStudents();
             if (students.length > 0) {
-                const oldGradings = await Promise.all(students.map((student) => this.findOfStudentAndHandIn(student.id, handIn.id)));
-                const oldGradingIds = new Set(oldGradings.map((grading) => grading?.id).filter((gradingId) => gradingId));
+                const oldGradings = await Promise.all(
+                    students.map((student) => this.findOfStudentAndHandIn(student.id, handIn.id))
+                );
+                const oldGradingIds = new Set(
+                    oldGradings.map((grading) => grading?.id).filter((gradingId) => gradingId)
+                );
                 if (oldGradingIds.size > 1) {
                     // noinspection ExceptionCaughtLocallyJS
                     throw new BadRequestException('Students have different gradings.');
                 }
-                const oldGrading = oldGradings[0]
+                const oldGrading = oldGradings[0];
                 const newGrading =
                     !oldGrading || dto.createNewGrading ? new Grading({ handIn }) : oldGrading;
 

--- a/server/src/module/student/student.module.ts
+++ b/server/src/module/student/student.module.ts
@@ -8,6 +8,9 @@ import { GradingService } from './grading.service';
 import { StudentController } from './student.controller';
 import { StudentService } from './student.service';
 import { GradingController } from './grading.controller';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Grading } from 'database/entities/grading.entity';
+import { Student } from 'database/entities/student.entity';
 
 @Module({
     imports: [
@@ -16,6 +19,7 @@ import { GradingController } from './grading.controller';
         SheetModule,
         ScheinexamModule,
         ShortTestModule,
+        MikroOrmModule.forFeature([Grading, Student])
     ],
     controllers: [StudentController, GradingController],
     providers: [StudentService, GradingService],

--- a/server/src/module/student/student.module.ts
+++ b/server/src/module/student/student.module.ts
@@ -19,7 +19,7 @@ import { Student } from '../../database/entities/student.entity';
         SheetModule,
         ScheinexamModule,
         ShortTestModule,
-        MikroOrmModule.forFeature([Grading, Student])
+        MikroOrmModule.forFeature([Grading, Student]),
     ],
     controllers: [StudentController, GradingController],
     providers: [StudentService, GradingService],

--- a/server/src/module/student/student.module.ts
+++ b/server/src/module/student/student.module.ts
@@ -9,8 +9,8 @@ import { StudentController } from './student.controller';
 import { StudentService } from './student.service';
 import { GradingController } from './grading.controller';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
-import { Grading } from 'database/entities/grading.entity';
-import { Student } from 'database/entities/student.entity';
+import { Grading } from '../../database/entities/grading.entity';
+import { Student } from '../../database/entities/student.entity';
 
 @Module({
     imports: [

--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -24,7 +24,7 @@ export class StudentService implements CRUDService<IStudent, StudentDTO, Student
         private readonly sheetService: SheetService,
         @InjectRepository(Student)
         private readonly repository: EntityRepository<Student>
-    ) { }
+    ) {}
 
     /**
      * @returns All students saved in the database.

--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -1,5 +1,5 @@
 import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import { forwardRef, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { IAttendance } from 'shared/model/Attendance';
 import { IStudent } from 'shared/model/Student';
@@ -15,7 +15,6 @@ import { AttendanceDTO, CakeCountDTO, PresentationPointsDTO, StudentDTO } from '
 @Injectable()
 export class StudentService implements CRUDService<IStudent, StudentDTO, Student> {
     private readonly logger = new Logger(StudentService.name);
-    private readonly repository: EntityRepository<Student>;
 
     constructor(
         @Inject(forwardRef(() => TutorialService))
@@ -23,10 +22,9 @@ export class StudentService implements CRUDService<IStudent, StudentDTO, Student
         @Inject(forwardRef(() => TeamService))
         private readonly teamService: TeamService,
         private readonly sheetService: SheetService,
-        entityManager: EntityManager
-    ) {
-        this.repository = entityManager.fork().getRepository(Student);
-    }
+        @InjectRepository(Student)
+        private readonly repository: EntityRepository<Student>
+    ) { }
 
     /**
      * @returns All students saved in the database.

--- a/server/src/module/team/team.module.ts
+++ b/server/src/module/team/team.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
-import { Team } from 'database/entities/team.entity';
+import { Team } from '../../database/entities/team.entity';
 import { StudentModule } from '../student/student.module';
 import { TutorialModule } from '../tutorial/tutorial.module';
 import { TeamController } from './team.controller';

--- a/server/src/module/team/team.module.ts
+++ b/server/src/module/team/team.module.ts
@@ -1,11 +1,17 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
+import { Team } from 'database/entities/team.entity';
 import { StudentModule } from '../student/student.module';
 import { TutorialModule } from '../tutorial/tutorial.module';
 import { TeamController } from './team.controller';
 import { TeamService } from './team.service';
 
 @Module({
-    imports: [forwardRef(() => StudentModule), forwardRef(() => TutorialModule)],
+    imports: [
+        forwardRef(() => StudentModule),
+        forwardRef(() => TutorialModule),
+        MikroOrmModule.forFeature([Team]),
+    ],
     providers: [TeamService],
     controllers: [TeamController],
     exports: [TeamService],

--- a/server/src/module/team/team.service.ts
+++ b/server/src/module/team/team.service.ts
@@ -1,5 +1,6 @@
 import { EntityRepository } from '@mikro-orm/core';
 import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import {
     BadRequestException,
     forwardRef,
@@ -18,7 +19,6 @@ import { TeamDTO } from './team.dto';
 
 @Injectable()
 export class TeamService {
-    private readonly repository: EntityRepository<Team>;
 
     constructor(
         @Inject(forwardRef(() => TutorialService))
@@ -27,10 +27,9 @@ export class TeamService {
         private readonly studentService: StudentService,
         @Inject(forwardRef(() => GradingService))
         private readonly gradingService: GradingService,
-        entityManager: EntityManager
-    ) {
-        this.repository = entityManager.fork().getRepository(Team);
-    }
+        @InjectRepository(Team)
+        private readonly repository: EntityRepository<Team>
+    ) { }
 
     /**
      * @param tutorialId Tutorial ID to get teams for

--- a/server/src/module/team/team.service.ts
+++ b/server/src/module/team/team.service.ts
@@ -1,5 +1,4 @@
 import { EntityRepository } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import {
     BadRequestException,
@@ -19,7 +18,6 @@ import { TeamDTO } from './team.dto';
 
 @Injectable()
 export class TeamService {
-
     constructor(
         @Inject(forwardRef(() => TutorialService))
         private readonly tutorialService: TutorialService,
@@ -29,7 +27,7 @@ export class TeamService {
         private readonly gradingService: GradingService,
         @InjectRepository(Team)
         private readonly repository: EntityRepository<Team>
-    ) { }
+    ) {}
 
     /**
      * @param tutorialId Tutorial ID to get teams for

--- a/server/src/module/template/template.module.ts
+++ b/server/src/module/template/template.module.ts
@@ -1,4 +1,4 @@
-import { MikroORM, UseRequestContext } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/core';
 import { Module, OnApplicationBootstrap } from '@nestjs/common';
 import { TemplateService } from './template.service';
 
@@ -7,7 +7,10 @@ import { TemplateService } from './template.service';
     exports: [TemplateService],
 })
 export class TemplateModule implements OnApplicationBootstrap {
-    constructor(private readonly templateService: TemplateService, private readonly orm: MikroORM) {}
+    constructor(
+        private readonly templateService: TemplateService,
+        private readonly orm: MikroORM
+    ) {}
 
     onApplicationBootstrap(): void {
         this.templateService.checkAllTemplatesPresent();

--- a/server/src/module/template/template.module.ts
+++ b/server/src/module/template/template.module.ts
@@ -1,3 +1,4 @@
+import { MikroORM, UseRequestContext } from '@mikro-orm/core';
 import { Module, OnApplicationBootstrap } from '@nestjs/common';
 import { TemplateService } from './template.service';
 
@@ -6,7 +7,7 @@ import { TemplateService } from './template.service';
     exports: [TemplateService],
 })
 export class TemplateModule implements OnApplicationBootstrap {
-    constructor(private readonly templateService: TemplateService) {}
+    constructor(private readonly templateService: TemplateService, private readonly orm: MikroORM) {}
 
     onApplicationBootstrap(): void {
         this.templateService.checkAllTemplatesPresent();

--- a/server/src/module/template/template.module.ts
+++ b/server/src/module/template/template.module.ts
@@ -1,4 +1,3 @@
-import { MikroORM } from '@mikro-orm/core';
 import { Module, OnApplicationBootstrap } from '@nestjs/common';
 import { TemplateService } from './template.service';
 
@@ -7,10 +6,7 @@ import { TemplateService } from './template.service';
     exports: [TemplateService],
 })
 export class TemplateModule implements OnApplicationBootstrap {
-    constructor(
-        private readonly templateService: TemplateService,
-        private readonly orm: MikroORM
-    ) {}
+    constructor(private readonly templateService: TemplateService) {}
 
     onApplicationBootstrap(): void {
         this.templateService.checkAllTemplatesPresent();

--- a/server/src/module/tutorial/tutorial.module.ts
+++ b/server/src/module/tutorial/tutorial.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
-import { Tutorial } from 'database/entities/tutorial.entity';
+import { Tutorial } from '../../database/entities/tutorial.entity';
 import { StudentModule } from '../student/student.module';
 import { UserModule } from '../user/user.module';
 import { TutorialController } from './tutorial.controller';

--- a/server/src/module/tutorial/tutorial.module.ts
+++ b/server/src/module/tutorial/tutorial.module.ts
@@ -1,11 +1,13 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
+import { Tutorial } from 'database/entities/tutorial.entity';
 import { StudentModule } from '../student/student.module';
 import { UserModule } from '../user/user.module';
 import { TutorialController } from './tutorial.controller';
 import { TutorialService } from './tutorial.service';
 
 @Module({
-    imports: [forwardRef(() => UserModule), forwardRef(() => StudentModule)],
+    imports: [forwardRef(() => UserModule), forwardRef(() => StudentModule), MikroOrmModule.forFeature([Tutorial])],
     providers: [TutorialService],
     controllers: [TutorialController],
     exports: [TutorialService],

--- a/server/src/module/tutorial/tutorial.module.ts
+++ b/server/src/module/tutorial/tutorial.module.ts
@@ -7,7 +7,11 @@ import { TutorialController } from './tutorial.controller';
 import { TutorialService } from './tutorial.service';
 
 @Module({
-    imports: [forwardRef(() => UserModule), forwardRef(() => StudentModule), MikroOrmModule.forFeature([Tutorial])],
+    imports: [
+        forwardRef(() => UserModule),
+        forwardRef(() => StudentModule),
+        MikroOrmModule.forFeature([Tutorial]),
+    ],
     providers: [TutorialService],
     controllers: [TutorialController],
     exports: [TutorialService],

--- a/server/src/module/tutorial/tutorial.service.ts
+++ b/server/src/module/tutorial/tutorial.service.ts
@@ -1,5 +1,6 @@
 import { EntityRepository } from '@mikro-orm/core';
 import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import {
     BadRequestException,
     forwardRef,
@@ -26,17 +27,16 @@ import {
 
 @Injectable()
 export class TutorialService implements CRUDService<ITutorial, TutorialDTO, Tutorial> {
-    private readonly repository: EntityRepository<Tutorial>;
 
     constructor(
         @Inject(forwardRef(() => UserService))
         private readonly userService: UserService,
         @Inject(forwardRef(() => StudentService))
         private readonly studentService: StudentService,
-        private readonly entityManager: EntityManager
-    ) {
-        this.repository = entityManager.fork().getRepository(Tutorial);
-    }
+        private readonly entityManager: EntityManager,
+        @InjectRepository(Tutorial)
+        private readonly repository: EntityRepository<Tutorial>
+    ) { }
 
     /**
      * @returns All tutorials saved in the database.

--- a/server/src/module/tutorial/tutorial.service.ts
+++ b/server/src/module/tutorial/tutorial.service.ts
@@ -167,16 +167,10 @@ export class TutorialService implements CRUDService<ITutorial, TutorialDTO, Tuto
             throw new BadRequestException(`A tutorial with students can NOT be deleted.`);
         }
 
-        const em = this.entityManager.fork({ clear: false });
-        await em.begin();
-        try {
-            tutorial.teams.getItems().map((team) => em.remove(team));
-            em.remove(tutorial);
-            await em.commit();
-        } catch (e) {
-            await em.rollback();
-            throw new BadRequestException(e);
-        }
+        this.entityManager.remove(tutorial.teams.getItems());
+        this.entityManager.remove(tutorial.substitutes.getItems())
+
+        await this.repository.removeAndFlush(tutorial);
     }
 
     /**

--- a/server/src/module/tutorial/tutorial.service.ts
+++ b/server/src/module/tutorial/tutorial.service.ts
@@ -35,7 +35,7 @@ export class TutorialService implements CRUDService<ITutorial, TutorialDTO, Tuto
         private readonly entityManager: EntityManager,
         @InjectRepository(Tutorial)
         private readonly repository: EntityRepository<Tutorial>
-    ) { }
+    ) {}
 
     /**
      * @returns All tutorials saved in the database.
@@ -257,7 +257,9 @@ export class TutorialService implements CRUDService<ITutorial, TutorialDTO, Tuto
 
         const existingSubstitutes = await this.getSubstitutesForDates(tutorial, dates);
         dates.forEach((date) => {
-            const existingSubstitute = existingSubstitutes.find((substitute) => +substitute.date === +date);
+            const existingSubstitute = existingSubstitutes.find(
+                (substitute) => +substitute.date === +date
+            );
             if (existingSubstitute) {
                 existingSubstitute.substituteTutor = tutor;
                 this.entityManager.persist(existingSubstitute);

--- a/server/src/module/tutorial/tutorial.service.ts
+++ b/server/src/module/tutorial/tutorial.service.ts
@@ -168,7 +168,7 @@ export class TutorialService implements CRUDService<ITutorial, TutorialDTO, Tuto
         }
 
         this.entityManager.remove(tutorial.teams.getItems());
-        this.entityManager.remove(tutorial.substitutes.getItems())
+        this.entityManager.remove(tutorial.substitutes.getItems());
 
         await this.repository.removeAndFlush(tutorial);
     }

--- a/server/src/module/user/user.module.ts
+++ b/server/src/module/user/user.module.ts
@@ -1,10 +1,12 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
+import { User } from 'database/entities/user.entity';
 import { TutorialModule } from '../tutorial/tutorial.module';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
 @Module({
-    imports: [forwardRef(() => TutorialModule)],
+    imports: [forwardRef(() => TutorialModule), MikroOrmModule.forFeature([User])],
     controllers: [UserController],
     providers: [UserService],
     exports: [UserService],

--- a/server/src/module/user/user.module.ts
+++ b/server/src/module/user/user.module.ts
@@ -1,6 +1,6 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { forwardRef, Module } from '@nestjs/common';
-import { User } from 'database/entities/user.entity';
+import { User } from '../../database/entities/user.entity';
 import { TutorialModule } from '../tutorial/tutorial.module';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';

--- a/server/src/module/user/user.service.ts
+++ b/server/src/module/user/user.service.ts
@@ -137,7 +137,7 @@ export class UserService implements OnApplicationBootstrap, CRUDService<IUser, U
         }
 
         if (errors.length === 0) {
-            await this.repository.persistAndFlush(toCreate)
+            await this.repository.persistAndFlush(toCreate);
         } else {
             throw new BadRequestException(errors);
         }

--- a/server/src/module/user/user.service.ts
+++ b/server/src/module/user/user.service.ts
@@ -123,8 +123,6 @@ export class UserService implements OnApplicationBootstrap, CRUDService<IUser, U
      * @returns Created users.
      */
     async createMany(users: CreateUserDTO[]): Promise<IUser[]> {
-        const em = this.entityManager.fork({ clear: false });
-        await em.begin();
         const errors: string[] = [];
         const toCreate: User[] = [];
 
@@ -139,12 +137,8 @@ export class UserService implements OnApplicationBootstrap, CRUDService<IUser, U
         }
 
         if (errors.length === 0) {
-            toCreate.forEach((user) => {
-                em.persist(user);
-            });
-            await em.commit();
+            await this.repository.persistAndFlush(toCreate)
         } else {
-            await em.rollback();
             throw new BadRequestException(errors);
         }
 

--- a/server/src/module/user/user.service.ts
+++ b/server/src/module/user/user.service.ts
@@ -1,5 +1,6 @@
-import { Collection, EntityRepository } from '@mikro-orm/core';
+import { Collection, EntityRepository, MikroORM, UseRequestContext } from '@mikro-orm/core';
 import { EntityManager } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import {
     BadRequestException,
     forwardRef,
@@ -7,7 +8,7 @@ import {
     Injectable,
     Logger,
     NotFoundException,
-    OnApplicationBootstrap,
+    OnApplicationBootstrap
 } from '@nestjs/common';
 import { NamedElement } from 'shared/model/Common';
 import { Role } from 'shared/model/Role';
@@ -22,19 +23,20 @@ import { CreateUserDTO, UserDTO } from './user.dto';
 @Injectable()
 export class UserService implements OnApplicationBootstrap, CRUDService<IUser, UserDTO, User> {
     private readonly logger = new Logger(UserService.name);
-    private readonly repository: EntityRepository<User>;
 
     constructor(
         @Inject(forwardRef(() => TutorialService))
         private readonly tutorialService: TutorialService,
-        private readonly entityManager: EntityManager
-    ) {
-        this.repository = entityManager.fork().getRepository(User);
-    }
+        private readonly entityManager: EntityManager,
+        private readonly orm: MikroORM,
+        @InjectRepository(User)
+        private readonly repository: EntityRepository<User>
+    ) { }
 
     /**
      * Creates a new administrator on application start if there are no users present in the DB.
      */
+    @UseRequestContext()
     async onApplicationBootstrap(): Promise<void> {
         const areUsersPresent = (await this.repository.findAll()).length > 0;
 

--- a/server/src/module/user/user.service.ts
+++ b/server/src/module/user/user.service.ts
@@ -8,7 +8,7 @@ import {
     Injectable,
     Logger,
     NotFoundException,
-    OnApplicationBootstrap
+    OnApplicationBootstrap,
 } from '@nestjs/common';
 import { NamedElement } from 'shared/model/Common';
 import { Role } from 'shared/model/Role';
@@ -31,7 +31,7 @@ export class UserService implements OnApplicationBootstrap, CRUDService<IUser, U
         private readonly orm: MikroORM,
         @InjectRepository(User)
         private readonly repository: EntityRepository<User>
-    ) { }
+    ) {}
 
     /**
      * Creates a new administrator on application start if there are no users present in the DB.

--- a/server/test/helpers/test.module.ts
+++ b/server/test/helpers/test.module.ts
@@ -13,7 +13,7 @@ import { StaticSettings } from '../../src/module/settings/settings.static';
 import { ENTITY_LISTS, populateMockLists } from '../mocks/entities.mock';
 
 @Module({
-    imports: [loadDatabaseModule()],
+    imports: [loadDatabaseModule({ allowGlobalContext: true })],
 })
 export class TestDatabaseModule {
     constructor(private readonly orm: MikroORM) {

--- a/server/test/helpers/test.module.ts
+++ b/server/test/helpers/test.module.ts
@@ -31,6 +31,12 @@ export class TestDatabaseModule {
     }
 
     async reset(): Promise<void> {
+        this.entityManager.clear();
+        return this.resetInContext();
+    }
+
+    @UseRequestContext()
+    private async resetInContext(): Promise<void> {
         const dbName = StaticSettings.getService().getDatabaseConnectionInformation().dbName;
         const connection = this.orm.em.getConnection();
         const allTables = await connection.execute(`SHOW TABLES FROM \`${dbName}\``);
@@ -68,6 +74,6 @@ export class TestDatabaseModule {
     }
 
     private async generateMocks() {
-        await populateMockLists(this.entityManager);
+        await populateMockLists();
     }
 }

--- a/server/test/mocks/entities.mock.ts
+++ b/server/test/mocks/entities.mock.ts
@@ -1,4 +1,3 @@
-import { EntityManager } from '@mikro-orm/core';
 import { DateTime } from 'luxon';
 import { Role } from 'shared/model/Role';
 import { ScheincriteriaIdentifier } from 'shared/model/ScheinCriteria';
@@ -51,7 +50,7 @@ function clearArray(array: any[]): void {
     array.splice(0, array.length);
 }
 
-export async function populateMockLists(em: EntityManager): Promise<void> {
+export async function populateMockLists(): Promise<void> {
     clearArray(MOCKED_USERS);
     MOCKED_USERS.push(
         new User({
@@ -322,16 +321,10 @@ export async function populateMockLists(em: EntityManager): Promise<void> {
     clearArray(MOCKED_SETTINGS_DOCUMENT);
     MOCKED_SETTINGS_DOCUMENT.push(Setting.fromDTO());
 
-    await adjustMocksWithAdditionalInformation(em);
+    await adjustMocksWithAdditionalInformation();
 }
 
-async function adjustMocksWithAdditionalInformation(em: EntityManager): Promise<void> {
-    for (const entities of ENTITY_LISTS) {
-        em.persist(entities);
-    }
-
-    await em.flush();
-
+async function adjustMocksWithAdditionalInformation(): Promise<void> {
     MOCKED_USERS[3].tutorialsToCorrect.add(MOCKED_TUTORIALS[0], MOCKED_TUTORIALS[2]);
 
     MOCKED_TUTORIALS[1].tutor = MOCKED_USERS[2];


### PR DESCRIPTION
# :ticket: Description
fixes a few bugs mostly regarding persistency:
- no manual forking of the EntityManager
  - for test, allow global context and reset manually (however execute setup and reset itself with context)
  - inject repositories
  - remove other fork occurences
  - this fixes a bug of new requests showing outdated data, giving the impression changes were not persisted
- delete substitutes on tutorial delete (fixes failing test)
- fix substitutes cannot be updated if at least one substitute exists
- fix logic which checks if team members have different gradings (fixes issues where update fails if team has only one member)

# :lock: Closes
