### PR TITLE
fix csv upload: accept correct content type

### DIFF
--- a/client/src/components/UploadFileButton.tsx
+++ b/client/src/components/UploadFileButton.tsx
@@ -39,10 +39,6 @@ function UploadFileButton({
     async (file: File) => {
       setLoading(true);
 
-      if (!supportedFileTypes.includes(file.type)) {
-        return;
-      }
-
       const content: string = await file.text();
       const cb = onFileSelect(content, file);
 
@@ -50,7 +46,7 @@ function UploadFileButton({
 
       setLoading(false);
     },
-    [supportedFileTypes, onFileSelect]
+    [onFileSelect]
   );
 
   const handleFileUpload = useCallback(
@@ -77,7 +73,7 @@ function UploadFileButton({
     >
       <Box display='flex'>
         <input
-          accept='.csv'
+          accept={supportedFileTypes.join(",")}
           style={{ display: 'none' }}
           id='icon-button-file'
           type='file'

--- a/client/src/components/UploadFileButton.tsx
+++ b/client/src/components/UploadFileButton.tsx
@@ -73,7 +73,7 @@ function UploadFileButton({
     >
       <Box display='flex'>
         <input
-          accept={supportedFileTypes.join(",")}
+          accept={supportedFileTypes.join(',')}
           style={{ display: 'none' }}
           id='icon-button-file'
           type='file'

--- a/client/src/components/import-csv/components/ImportCSVFromFile.tsx
+++ b/client/src/components/import-csv/components/ImportCSVFromFile.tsx
@@ -1,6 +1,5 @@
 import { Box, Grow, Typography } from '@material-ui/core';
 import { FileCheckOutline as FileSelectedIcon } from 'mdi-material-ui';
-import React from 'react';
 import OutlinedBox from '../../OutlinedBox';
 import UploadFileButton from '../../UploadFileButton';
 
@@ -18,7 +17,7 @@ function ImportCSVFromFile({ fileInfo, onFileInfoChanged }: ImportCSVFromFilePro
   return (
     <>
       <UploadFileButton
-        supportedFileTypes={['application/vnd.ms-excel']}
+        supportedFileTypes={['text/csv']}
         onFileSelect={(content: string, file: File) =>
           onFileInfoChanged({ content, fileName: file.name })
         }


### PR DESCRIPTION
# :ticket: Description
Fixes the bug that the csv import loads forever.
- replaces hardcoded .csv in `accept` with the content types
- remove check for content type afterwards as it is now already checked by the upload itself (therefore it can never be an invalid content type), and if the validation fails it would only cause the bug of an infinite load
- changes the content type for the csv import to `text/csv`, as `application/vnd.ms-excel` [seems to be .xls and not .csv](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)

# :lock: Closes
- Fixes #1011 
