### PR TITLE
fix grading of exercises with subexercises

### DIFF
--- a/client/src/model/Grading.ts
+++ b/client/src/model/Grading.ts
@@ -72,7 +72,7 @@ export class Grading implements Modify<IGrading, Modified> {
         let sum = this.additionalPoints ?? 0;
 
         for (const [, doc] of this.exerciseGradings) {
-            sum += doc.points;
+            sum += doc.totalPoints;
         }
 
         return sum;

--- a/server/src/database/entities/grading.entity.ts
+++ b/server/src/database/entities/grading.entity.ts
@@ -42,6 +42,21 @@ export class ExerciseGrading {
         this.points = points;
     }
 
+    /**
+     * @returns Sum of all points of all subExercises, points of this exercise grading
+     * and the `additionalPoints` of this exercise grading.
+     */
+    get totalPoints(): number {
+        if (this.subExercisePoints.size > 0) {
+            return (
+                (this.additionalPoints ?? 0) +
+                [...this.subExercisePoints.values()].reduce((sum, points) => sum + points, 0)
+            );
+        } else {
+            return this.points + (this.additionalPoints ?? 0);
+        }
+    }
+
     getGradingForSubExercise(subEx: SubExercise): number | undefined {
         return this.subExercisePoints.get(subEx.id);
     }
@@ -112,7 +127,10 @@ export class Grading {
     get points(): number {
         const additional = this.additionalPoints ?? 0;
 
-        return additional + this.exerciseGradings.reduce((sum, grading) => sum + grading.points, 0);
+        return (
+            additional +
+            this.exerciseGradings.reduce((sum, grading) => sum + grading.totalPoints, 0)
+        );
     }
 
     get handIn(): HandIn {

--- a/server/src/module/markdown/markdown.service.ts
+++ b/server/src/module/markdown/markdown.service.ts
@@ -259,7 +259,7 @@ export class MarkdownService {
             pointInfo.total.must += total.must;
             pointInfo.total.bonus += total.bonus;
 
-            const achieved = gradingForExercise?.points ?? 0;
+            const achieved = gradingForExercise?.totalPoints ?? 0;
             const exMaxPoints = convertExercisePointInfoToString(total);
             const subExTable = gradingForExercise
                 ? this.generateSubExerciseTable({


### PR DESCRIPTION
# :ticket: Description
Fixes grading point bugs with exercises with subexercises
- adds totalPoints to entity
- use in points of property of entity to fulfill contract
- use new totalPoints in pdf generation
- fix frontend Grading entity to use totalPoints

# :lock: Closes
- Closes #1023 
